### PR TITLE
fix(rpc): align block number input behaviour for eth_getProof (backport: #1639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (rpc) [#1613](https://github.com/evmos/ethermint/pull/1613) Change the default json-rpc listen address to localhost.
 * (rpc) [#1638](https://github.com/evmos/ethermint/pull/1638) Align results when querying `eth_getTransactionCount` for future blocks for accounts with zero and non-zero transaction counts.
 * (rpc) [#1688](https://github.com/evmos/ethermint/pull/1688) Align filter rule for `debug_traceBlockByNumber`
+* (rpc) [#1639](https://github.com/evmos/ethermint/pull/1639) Align block number input behaviour for `eth_getProof` as Ethereum.
 
 ### Improvements
 

--- a/rpc/backend/account_info_test.go
+++ b/rpc/backend/account_info_test.go
@@ -118,20 +118,20 @@ func (suite *BackendTestSuite) TestGetProof() {
 				RegisterAccount(queryClient, addr, bn.Int64())
 
 				// Use the IAVL height if a valid tendermint height is passed in.
-				ivalHeight := bn.Int64() - 1
+				iavlHeight := bn.Int64()
 				RegisterABCIQueryWithOptions(
 					client,
 					bn.Int64(),
 					"store/evm/key",
 					evmtypes.StateKey(address1, common.HexToHash("0x0").Bytes()),
-					tmrpcclient.ABCIQueryOptions{Height: ivalHeight, Prove: true},
+					tmrpcclient.ABCIQueryOptions{Height: iavlHeight, Prove: true},
 				)
 				RegisterABCIQueryWithOptions(
 					client,
 					bn.Int64(),
 					"store/acc/key",
 					authtypes.AddressStoreKey(sdk.AccAddress(address1.Bytes())),
-					tmrpcclient.ABCIQueryOptions{Height: ivalHeight, Prove: true},
+					tmrpcclient.ABCIQueryOptions{Height: iavlHeight, Prove: true},
 				)
 			},
 			true,

--- a/rpc/types/query_client.go
+++ b/rpc/types/query_client.go
@@ -47,9 +47,6 @@ func (QueryClient) GetProof(clientCtx client.Context, storeKey string, key []byt
 		return nil, nil, fmt.Errorf("proof queries at height <= 2 are not supported")
 	}
 
-	// Use the IAVL height if a valid tendermint height is passed in.
-	height--
-
 	abciReq := abci.RequestQuery{
 		Path:   fmt.Sprintf("store/%s/key", storeKey),
 		Data:   key,

--- a/tests/integration_tests/contracts/contracts/StateContract.sol
+++ b/tests/integration_tests/contracts/contracts/StateContract.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StateContract {
+    address payable private owner;
+    uint256 storedData;
+
+    constructor() {
+        owner = payable(msg.sender);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "tx sender is not contract owner");
+        _;
+    }
+
+    function add(uint256 a, uint256 b) public returns (uint256) {
+        storedData = a + b;
+        return storedData;
+    }
+
+    function get() public view returns (uint256) {
+        return storedData;
+    }
+
+    function destruct() public onlyOwner {
+        selfdestruct(owner);
+    }
+}

--- a/tests/integration_tests/test_storage_proof.py
+++ b/tests/integration_tests/test_storage_proof.py
@@ -1,0 +1,41 @@
+import pytest
+
+from .network import setup_ethermint
+from .utils import CONTRACTS, deploy_contract
+
+
+@pytest.fixture(scope="module")
+def custom_ethermint(tmp_path_factory):
+    path = tmp_path_factory.mktemp("storage-proof")
+    yield from setup_ethermint(path, 26800, long_timeout_commit=True)
+
+
+@pytest.fixture(scope="module", params=["ethermint", "geth"])
+def cluster(request, custom_ethermint, geth):
+    """
+    run on both ethermint and geth
+    """
+    provider = request.param
+    if provider == "ethermint":
+        yield custom_ethermint
+    elif provider == "geth":
+        yield geth
+    else:
+        raise NotImplementedError
+
+
+def test_basic(cluster):
+    _, res = deploy_contract(
+        cluster.w3,
+        CONTRACTS["StateContract"],
+    )
+    method = "eth_getProof"
+    storage_keys = ["0x0", "0x1"]
+    proof = (
+        cluster.w3.provider.make_request(
+            method, [res["contractAddress"], storage_keys, hex(res["blockNumber"])]
+        )
+    )["result"]
+    for proof in proof["storageProof"]:
+        if proof["key"] == storage_keys[0]:
+            assert proof["value"] != "0x0"

--- a/tests/integration_tests/test_storage_proof.py
+++ b/tests/integration_tests/test_storage_proof.py
@@ -1,7 +1,7 @@
 import pytest
 
 from .network import setup_ethermint
-from .utils import CONTRACTS, deploy_contract
+from .utils import CONTRACTS, deploy_contract_with_receipt
 
 
 @pytest.fixture(scope="module")
@@ -25,7 +25,7 @@ def cluster(request, custom_ethermint, geth):
 
 
 def test_basic(cluster):
-    _, res = deploy_contract(
+    _, res = deploy_contract_with_receipt(
         cluster.w3,
         CONTRACTS["StateContract"],
     )

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -30,6 +30,8 @@ TEST_CONTRACTS = {
     "Greeter": "Greeter.sol",
     "TestChainID": "ChainID.sol",
     "TestExploitContract": "TestExploitContract.sol",
+    "Mars": "Mars.sol",
+    "StateContract": "StateContract.sol",
 }
 
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -123,7 +123,7 @@ def wait_for_block_time(cli, t):
         time.sleep(0.5)
 
 
-def deploy_contract(w3, jsonfile, args=(), key=KEYS["validator"]):
+def deploy_contract_with_receipt(w3, jsonfile, args=(), key=KEYS["validator"]):
     """
     deploy contract and return the deployed contract instance
     """
@@ -134,7 +134,15 @@ def deploy_contract(w3, jsonfile, args=(), key=KEYS["validator"]):
     txreceipt = send_transaction(w3, tx, key)
     assert txreceipt.status == 1
     address = txreceipt.contractAddress
-    return w3.eth.contract(address=address, abi=info["abi"])
+    return w3.eth.contract(address=address, abi=info["abi"]), txreceipt
+
+
+def deploy_contract(w3, jsonfile, args=(), key=KEYS["validator"]):
+    """
+    deploy contract and return the deployed contract instance
+    """
+    contract, _ = deploy_contract_with_receipt(w3, jsonfile, args, key)
+    return contract
 
 
 def fill_defaults(w3, tx):

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -30,7 +30,6 @@ TEST_CONTRACTS = {
     "Greeter": "Greeter.sol",
     "TestChainID": "ChainID.sol",
     "TestExploitContract": "TestExploitContract.sol",
-    "Mars": "Mars.sol",
     "StateContract": "StateContract.sol",
 }
 


### PR DESCRIPTION
for more info: https://github.com/evmos/ethermint/pull/1639

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
