### PR TITLE
Problem: DecodeTxResponses don't ignore non-eth msgs

### DIFF
--- a/x/evm/types/utils.go
+++ b/x/evm/types/utils.go
@@ -55,14 +55,17 @@ func DecodeTxResponses(in []byte) ([]*MsgEthereumTxResponse, error) {
 	if err := proto.Unmarshal(in, &txMsgData); err != nil {
 		return nil, err
 	}
-
-	responses := make([]*MsgEthereumTxResponse, len(txMsgData.MsgResponses))
-	for i, res := range txMsgData.MsgResponses {
+	responses := make([]*MsgEthereumTxResponse, 0)
+	for _, res := range txMsgData.MsgResponses {
 		var response MsgEthereumTxResponse
-		if err := proto.Unmarshal(res.Value, &response); err != nil {
+		if res.TypeUrl != "/"+proto.MessageName(&response) {
+			continue
+		}
+		err := proto.Unmarshal(res.Value, &response)
+		if err != nil {
 			return nil, errorsmod.Wrap(err, "failed to unmarshal tx response message data")
 		}
-		responses[i] = &response
+		responses = append(responses, &response)
 	}
 	return responses, nil
 }

--- a/x/evm/types/utils.go
+++ b/x/evm/types/utils.go
@@ -55,7 +55,7 @@ func DecodeTxResponses(in []byte) ([]*MsgEthereumTxResponse, error) {
 	if err := proto.Unmarshal(in, &txMsgData); err != nil {
 		return nil, err
 	}
-	responses := make([]*MsgEthereumTxResponse, 0)
+	responses := make([]*MsgEthereumTxResponse, 0, len(txMsgData.MsgResponses))
 	for _, res := range txMsgData.MsgResponses {
 		var response MsgEthereumTxResponse
 		if res.TypeUrl != "/"+proto.MessageName(&response) {


### PR DESCRIPTION
this change should have been included in 199ccc232fd4cc5b0468b0cdec5e1ddaa340e116

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
