### PR TITLE
Problem: many repeated GetParams calls in ante handler

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -73,13 +73,13 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 				switch typeURL := opts[0].GetTypeUrl(); typeURL {
 				case "/ethermint.evm.v1.ExtensionOptionsEthereumTx":
 					// handle as *evmtypes.MsgEthereumTx
-					anteHandler = newEthAnteHandler(options, options.ExtraDecorators...)
+					anteHandler = newEthAnteHandler(ctx, options, options.ExtraDecorators...)
 				case "/ethermint.types.v1.ExtensionOptionsWeb3Tx":
 					// Deprecated: Handle as normal Cosmos SDK tx, except signature is checked for Legacy EIP712 representation
-					anteHandler = NewLegacyCosmosAnteHandlerEip712(options, options.ExtraDecorators...)
+					anteHandler = NewLegacyCosmosAnteHandlerEip712(ctx, options, options.ExtraDecorators...)
 				case "/ethermint.types.v1.ExtensionOptionDynamicFeeTx":
 					// cosmos-sdk tx with dynamic fee extension
-					anteHandler = newCosmosAnteHandler(options, options.ExtraDecorators...)
+					anteHandler = newCosmosAnteHandler(ctx, options, options.ExtraDecorators...)
 				default:
 					return ctx, errorsmod.Wrapf(
 						errortypes.ErrUnknownExtensionOptions,
@@ -94,7 +94,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		// handle as totally normal Cosmos SDK tx
 		switch tx.(type) {
 		case sdk.Tx:
-			anteHandler = newCosmosAnteHandler(options, options.ExtraDecorators...)
+			anteHandler = newCosmosAnteHandler(ctx, options, options.ExtraDecorators...)
 		default:
 			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid transaction type: %T", tx)
 		}

--- a/app/ante/eth.go
+++ b/app/ante/eth.go
@@ -27,24 +27,26 @@ import (
 
 	ethermint "github.com/evmos/ethermint/types"
 	"github.com/evmos/ethermint/x/evm/keeper"
-	"github.com/evmos/ethermint/x/evm/statedb"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // EthAccountVerificationDecorator validates an account balance checks
 type EthAccountVerificationDecorator struct {
 	ak        evmtypes.AccountKeeper
 	evmKeeper EVMKeeper
+	evmDenom  string
 }
 
 // NewEthAccountVerificationDecorator creates a new EthAccountVerificationDecorator
-func NewEthAccountVerificationDecorator(ak evmtypes.AccountKeeper, ek EVMKeeper) EthAccountVerificationDecorator {
+func NewEthAccountVerificationDecorator(ak evmtypes.AccountKeeper, ek EVMKeeper, evmDenom string) EthAccountVerificationDecorator {
 	return EthAccountVerificationDecorator{
 		ak:        ak,
 		evmKeeper: ek,
+		evmDenom:  evmDenom,
 	}
 }
 
@@ -93,7 +95,7 @@ func (avd EthAccountVerificationDecorator) AnteHandle(
 				"the sender is not EOA: address %s, codeHash <%s>", fromAddr, acct.CodeHash)
 		}
 
-		balance := avd.evmKeeper.GetEVMDenomBalance(ctx, fromAddr)
+		balance := avd.evmKeeper.GetBalance(ctx, sdk.AccAddress(fromAddr.Bytes()), avd.evmDenom)
 		if err := keeper.CheckSenderBalance(sdkmath.NewIntFromBigInt(balance), txData); err != nil {
 			return ctx, errorsmod.Wrap(err, "failed to check sender balance")
 		}
@@ -106,16 +108,25 @@ func (avd EthAccountVerificationDecorator) AnteHandle(
 type EthGasConsumeDecorator struct {
 	evmKeeper    EVMKeeper
 	maxGasWanted uint64
+	ethCfg       *params.ChainConfig
+	evmDenom     string
+	baseFee      *big.Int
 }
 
 // NewEthGasConsumeDecorator creates a new EthGasConsumeDecorator
 func NewEthGasConsumeDecorator(
 	evmKeeper EVMKeeper,
 	maxGasWanted uint64,
+	ethCfg *params.ChainConfig,
+	evmDenom string,
+	baseFee *big.Int,
 ) EthGasConsumeDecorator {
 	return EthGasConsumeDecorator{
 		evmKeeper,
 		maxGasWanted,
+		ethCfg,
+		evmDenom,
+		baseFee,
 	}
 }
 
@@ -149,18 +160,13 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 		return next(newCtx, tx, simulate)
 	}
 
-	evmParams := egcd.evmKeeper.GetParams(ctx)
-	chainCfg := evmParams.GetChainConfig()
-	ethCfg := chainCfg.EthereumConfig(egcd.evmKeeper.ChainID())
-
 	blockHeight := big.NewInt(ctx.BlockHeight())
-	homestead := ethCfg.IsHomestead(blockHeight)
-	istanbul := ethCfg.IsIstanbul(blockHeight)
+	homestead := egcd.ethCfg.IsHomestead(blockHeight)
+	istanbul := egcd.ethCfg.IsIstanbul(blockHeight)
 	var events sdk.Events
 
 	// Use the lowest priority of all the messages as the final one.
 	minPriority := int64(math.MaxInt64)
-	baseFee := egcd.evmKeeper.GetBaseFee(ctx, ethCfg)
 
 	for _, msg := range tx.GetMsgs() {
 		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
@@ -184,9 +190,7 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 			gasWanted += txData.GetGas()
 		}
 
-		evmDenom := evmParams.GetEvmDenom()
-
-		fees, err := keeper.VerifyFee(txData, evmDenom, baseFee, homestead, istanbul, ctx.IsCheckTx())
+		fees, err := keeper.VerifyFee(txData, egcd.evmDenom, egcd.baseFee, homestead, istanbul, ctx.IsCheckTx())
 		if err != nil {
 			return ctx, errorsmod.Wrapf(err, "failed to verify the fees")
 		}
@@ -203,7 +207,7 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 			),
 		)
 
-		priority := evmtypes.GetTxPriority(txData, baseFee)
+		priority := evmtypes.GetTxPriority(txData, egcd.baseFee)
 
 		if priority < minPriority {
 			minPriority = priority
@@ -246,66 +250,54 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 // context rules.
 type CanTransferDecorator struct {
 	evmKeeper EVMKeeper
+	baseFee   *big.Int
+	evmParams *evmtypes.Params
+	ethCfg    *params.ChainConfig
 }
 
 // NewCanTransferDecorator creates a new CanTransferDecorator instance.
-func NewCanTransferDecorator(evmKeeper EVMKeeper) CanTransferDecorator {
-	return CanTransferDecorator{evmKeeper}
+func NewCanTransferDecorator(evmKeeper EVMKeeper, baseFee *big.Int, evmParams *evmtypes.Params, ethCfg *params.ChainConfig) CanTransferDecorator {
+	return CanTransferDecorator{evmKeeper, baseFee, evmParams, ethCfg}
 }
 
 // AnteHandle creates an EVM from the message and calls the BlockContext CanTransfer function to
 // see if the address can execute the transaction.
 func (ctd CanTransferDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	params := ctd.evmKeeper.GetParams(ctx)
-	ethCfg := params.ChainConfig.EthereumConfig(ctd.evmKeeper.ChainID())
-	signer := ethtypes.MakeSigner(ethCfg, big.NewInt(ctx.BlockHeight()))
-
+	signer := ethtypes.MakeSigner(ctd.ethCfg, big.NewInt(ctx.BlockHeight()))
 	for _, msg := range tx.GetMsgs() {
 		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
 		if !ok {
 			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
 		}
 
-		baseFee := ctd.evmKeeper.GetBaseFee(ctx, ethCfg)
-
-		coreMsg, err := msgEthTx.AsMessage(signer, baseFee)
+		// passing nil signer because msg must have non-empty `From` address here.
+		coreMsg, err := msgEthTx.AsMessage(signer, ctd.baseFee)
 		if err != nil {
 			return ctx, errorsmod.Wrapf(
 				err,
-				"failed to create an ethereum core.Message from signer %T", signer,
+				"failed to create an ethereum core.Message",
 			)
 		}
 
-		if evmtypes.IsLondon(ethCfg, ctx.BlockHeight()) {
-			if baseFee == nil {
+		if evmtypes.IsLondon(ctd.ethCfg, ctx.BlockHeight()) {
+			if ctd.baseFee == nil {
 				return ctx, errorsmod.Wrap(
 					evmtypes.ErrInvalidBaseFee,
 					"base fee is supported but evm block context value is nil",
 				)
 			}
-			if coreMsg.GasFeeCap().Cmp(baseFee) < 0 {
+			if coreMsg.GasFeeCap().Cmp(ctd.baseFee) < 0 {
 				return ctx, errorsmod.Wrapf(
 					errortypes.ErrInsufficientFee,
 					"max fee per gas less than block base fee (%s < %s)",
-					coreMsg.GasFeeCap(), baseFee,
+					coreMsg.GasFeeCap(), ctd.baseFee,
 				)
 			}
 		}
 
-		// NOTE: pass in an empty coinbase address and nil tracer as we don't need them for the check below
-		cfg := &statedb.EVMConfig{
-			ChainConfig: ethCfg,
-			Params:      params,
-			CoinBase:    common.Address{},
-			BaseFee:     baseFee,
-		}
-
-		stateDB := statedb.New(ctx, ctd.evmKeeper, statedb.NewEmptyTxConfig(common.BytesToHash(ctx.HeaderHash().Bytes())))
-		evm := ctd.evmKeeper.NewEVM(ctx, coreMsg, cfg, evmtypes.NewNoOpTracer(), stateDB, nil)
-
 		// check that caller has enough balance to cover asset transfer for **topmost** call
 		// NOTE: here the gas consumed is from the context with the infinite gas meter
-		if coreMsg.Value().Sign() > 0 && !evm.Context.CanTransfer(stateDB, coreMsg.From(), coreMsg.Value()) {
+		if coreMsg.Value().Sign() > 0 && !canTransfer(ctx, ctd.evmKeeper, ctd.evmParams.EvmDenom, coreMsg.From(), coreMsg.Value()) {
 			return ctx, errorsmod.Wrapf(
 				errortypes.ErrInsufficientFunds,
 				"failed to transfer %s from address %s using the EVM block context transfer function",
@@ -316,6 +308,12 @@ func (ctd CanTransferDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 	}
 
 	return next(ctx, tx, simulate)
+}
+
+// canTransfer adapted the core.CanTransfer from go-ethereum
+func canTransfer(ctx sdk.Context, evmKeeper EVMKeeper, denom string, from common.Address, amount *big.Int) bool {
+	balance := evmKeeper.GetBalance(ctx, sdk.AccAddress(from.Bytes()), denom)
+	return balance.Cmp(amount) >= 0
 }
 
 // EthIncrementSenderSequenceDecorator increments the sequence of the signers.

--- a/app/ante/eth.go
+++ b/app/ante/eth.go
@@ -270,7 +270,6 @@ func (ctd CanTransferDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
 		}
 
-		// passing nil signer because msg must have non-empty `From` address here.
 		coreMsg, err := msgEthTx.AsMessage(signer, ctd.baseFee)
 		if err != nil {
 			return ctx, errorsmod.Wrapf(

--- a/app/ante/fee_market.go
+++ b/app/ante/fee_market.go
@@ -43,7 +43,6 @@ func NewGasWantedDecorator(
 }
 
 func (gwd GasWantedDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-
 	blockHeight := big.NewInt(ctx.BlockHeight())
 	isLondon := gwd.ethCfg.IsLondon(blockHeight)
 

--- a/app/ante/fee_market.go
+++ b/app/ante/fee_market.go
@@ -20,34 +20,32 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // GasWantedDecorator keeps track of the gasWanted amount on the current block in transient store
 // for BaseFee calculation.
 // NOTE: This decorator does not perform any validation
 type GasWantedDecorator struct {
-	evmKeeper       EVMKeeper
 	feeMarketKeeper FeeMarketKeeper
+	ethCfg          *params.ChainConfig
 }
 
 // NewGasWantedDecorator creates a new NewGasWantedDecorator
 func NewGasWantedDecorator(
-	evmKeeper EVMKeeper,
 	feeMarketKeeper FeeMarketKeeper,
+	ethCfg *params.ChainConfig,
 ) GasWantedDecorator {
 	return GasWantedDecorator{
-		evmKeeper,
 		feeMarketKeeper,
+		ethCfg,
 	}
 }
 
 func (gwd GasWantedDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	evmParams := gwd.evmKeeper.GetParams(ctx)
-	chainCfg := evmParams.GetChainConfig()
-	ethCfg := chainCfg.EthereumConfig(gwd.evmKeeper.ChainID())
 
 	blockHeight := big.NewInt(ctx.BlockHeight())
-	isLondon := ethCfg.IsLondon(blockHeight)
+	isLondon := gwd.ethCfg.IsLondon(blockHeight)
 
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok || !isLondon {

--- a/app/ante/fee_market_test.go
+++ b/app/ante/fee_market_test.go
@@ -15,7 +15,13 @@ import (
 func (suite AnteTestSuite) TestGasWantedDecorator() {
 	suite.enableFeemarket = true
 	suite.SetupTest()
-	dec := ante.NewGasWantedDecorator(suite.app.EvmKeeper, suite.app.FeeMarketKeeper)
+
+	evmParams := suite.app.EvmKeeper.GetParams(suite.ctx)
+	chainID := suite.app.EvmKeeper.ChainID()
+	chainCfg := evmParams.GetChainConfig()
+	ethCfg := chainCfg.EthereumConfig(chainID)
+
+	dec := ante.NewGasWantedDecorator(suite.app.FeeMarketKeeper, ethCfg)
 	from, fromPrivKey := tests.NewAddrKey()
 	to := tests.GenerateAddress()
 

--- a/app/ante/fees.go
+++ b/app/ante/fees.go
@@ -33,7 +33,7 @@ import (
 // CONTRACT: Tx must implement FeeTx to use MinGasPriceDecorator
 type MinGasPriceDecorator struct {
 	feesKeeper FeeMarketKeeper
-	evmKeeper  EVMKeeper
+	evmDenom   string
 }
 
 // EthMinGasPriceDecorator will check if the transaction's fee is at least as large
@@ -43,7 +43,7 @@ type MinGasPriceDecorator struct {
 // If fee is high enough, then call next AnteHandler
 type EthMinGasPriceDecorator struct {
 	feesKeeper FeeMarketKeeper
-	evmKeeper  EVMKeeper
+	baseFee    *big.Int
 }
 
 // EthMempoolFeeDecorator will check if the transaction's effective fee is at least as large
@@ -53,26 +53,28 @@ type EthMinGasPriceDecorator struct {
 // If fee is high enough or not CheckTx, then call next AnteHandler
 // CONTRACT: Tx must implement FeeTx to use MempoolFeeDecorator
 type EthMempoolFeeDecorator struct {
-	evmKeeper EVMKeeper
+	evmDenom string
+	baseFee  *big.Int
 }
 
 // NewMinGasPriceDecorator creates a new MinGasPriceDecorator instance used only for
 // Cosmos transactions.
-func NewMinGasPriceDecorator(fk FeeMarketKeeper, ek EVMKeeper) MinGasPriceDecorator {
-	return MinGasPriceDecorator{feesKeeper: fk, evmKeeper: ek}
+func NewMinGasPriceDecorator(fk FeeMarketKeeper, evmDenom string) MinGasPriceDecorator {
+	return MinGasPriceDecorator{feesKeeper: fk, evmDenom: evmDenom}
 }
 
 // NewEthMinGasPriceDecorator creates a new MinGasPriceDecorator instance used only for
 // Ethereum transactions.
-func NewEthMinGasPriceDecorator(fk FeeMarketKeeper, ek EVMKeeper) EthMinGasPriceDecorator {
-	return EthMinGasPriceDecorator{feesKeeper: fk, evmKeeper: ek}
+func NewEthMinGasPriceDecorator(fk FeeMarketKeeper, baseFee *big.Int) EthMinGasPriceDecorator {
+	return EthMinGasPriceDecorator{feesKeeper: fk, baseFee: baseFee}
 }
 
 // NewEthMempoolFeeDecorator creates a new NewEthMempoolFeeDecorator instance used only for
 // Ethereum transactions.
-func NewEthMempoolFeeDecorator(ek EVMKeeper) EthMempoolFeeDecorator {
+func NewEthMempoolFeeDecorator(evmDenom string, baseFee *big.Int) EthMempoolFeeDecorator {
 	return EthMempoolFeeDecorator{
-		evmKeeper: ek,
+		evmDenom: evmDenom,
+		baseFee:  baseFee,
 	}
 }
 
@@ -88,11 +90,9 @@ func (mpd MinGasPriceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 	if minGasPrice.IsZero() || simulate {
 		return next(ctx, tx, simulate)
 	}
-	evmParams := mpd.evmKeeper.GetParams(ctx)
-	evmDenom := evmParams.GetEvmDenom()
 	minGasPrices := sdk.DecCoins{
 		{
-			Denom:  evmDenom,
+			Denom:  mpd.evmDenom,
 			Amount: minGasPrice,
 		},
 	}
@@ -133,11 +133,6 @@ func (empd EthMinGasPriceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 		return next(ctx, tx, simulate)
 	}
 
-	evmParams := empd.evmKeeper.GetParams(ctx)
-	chainCfg := evmParams.GetChainConfig()
-	ethCfg := chainCfg.EthereumConfig(empd.evmKeeper.ChainID())
-	baseFee := empd.evmKeeper.GetBaseFee(ctx, ethCfg)
-
 	for _, msg := range tx.GetMsgs() {
 		ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
 		if !ok {
@@ -165,7 +160,7 @@ func (empd EthMinGasPriceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 		}
 
 		if txData.TxType() != ethtypes.LegacyTxType {
-			feeAmt = ethMsg.GetEffectiveFee(baseFee)
+			feeAmt = ethMsg.GetEffectiveFee(empd.baseFee)
 		}
 
 		gasLimit := sdk.NewDecFromBigInt(new(big.Int).SetUint64(ethMsg.GetGas()))
@@ -192,18 +187,12 @@ func (mfd EthMempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 	if !ctx.IsCheckTx() || simulate {
 		return next(ctx, tx, simulate)
 	}
-	evmParams := mfd.evmKeeper.GetParams(ctx)
-	chainCfg := evmParams.GetChainConfig()
-	ethCfg := chainCfg.EthereumConfig(mfd.evmKeeper.ChainID())
-
-	baseFee := mfd.evmKeeper.GetBaseFee(ctx, ethCfg)
 	// skip check as the London hard fork and EIP-1559 are enabled
-	if baseFee != nil {
+	if mfd.baseFee != nil {
 		return next(ctx, tx, simulate)
 	}
 
-	evmDenom := evmParams.GetEvmDenom()
-	minGasPrice := ctx.MinGasPrices().AmountOf(evmDenom)
+	minGasPrice := ctx.MinGasPrices().AmountOf(mfd.evmDenom)
 
 	for _, msg := range tx.GetMsgs() {
 		ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)

--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -67,25 +67,36 @@ func (options HandlerOptions) validate() error {
 	return nil
 }
 
-func newEthAnteHandler(options HandlerOptions, extra ...sdk.AnteDecorator) sdk.AnteHandler {
+func newEthAnteHandler(ctx sdk.Context, options HandlerOptions, extra ...sdk.AnteDecorator) sdk.AnteHandler {
+	evmParams := options.EvmKeeper.GetParams(ctx)
+	evmDenom := evmParams.EvmDenom
+	chainID := options.EvmKeeper.ChainID()
+	chainCfg := evmParams.GetChainConfig()
+	ethCfg := chainCfg.EthereumConfig(chainID)
+	baseFee := options.EvmKeeper.GetBaseFee(ctx, ethCfg)
 	decorators := []sdk.AnteDecorator{
-		NewEthSetUpContextDecorator(options.EvmKeeper),                         // outermost AnteDecorator. SetUpContext must be called first
-		NewEthMempoolFeeDecorator(options.EvmKeeper),                           // Check eth effective gas price against minimal-gas-prices
-		NewEthMinGasPriceDecorator(options.FeeMarketKeeper, options.EvmKeeper), // Check eth effective gas price against the global MinGasPrice
-		NewEthValidateBasicDecorator(options.EvmKeeper),
-		NewEthSigVerificationDecorator(options.EvmKeeper),
-		NewEthAccountVerificationDecorator(options.AccountKeeper, options.EvmKeeper),
-		NewCanTransferDecorator(options.EvmKeeper),
-		NewEthGasConsumeDecorator(options.EvmKeeper, options.MaxTxGasWanted),
+		NewEthSetUpContextDecorator(options.EvmKeeper),               // outermost AnteDecorator. SetUpContext must be called first
+		NewEthMempoolFeeDecorator(evmDenom, baseFee),                 // Check eth effective gas price against minimal-gas-prices
+		NewEthMinGasPriceDecorator(options.FeeMarketKeeper, baseFee), // Check eth effective gas price against the global MinGasPrice
+		NewEthValidateBasicDecorator(&evmParams, baseFee),
+		NewEthSigVerificationDecorator(ethCfg),
+		NewEthAccountVerificationDecorator(options.AccountKeeper, options.EvmKeeper, evmDenom),
+		NewCanTransferDecorator(options.EvmKeeper, baseFee, &evmParams, ethCfg),
+		NewEthGasConsumeDecorator(options.EvmKeeper, options.MaxTxGasWanted, ethCfg, evmDenom, baseFee),
 		NewEthIncrementSenderSequenceDecorator(options.AccountKeeper), // innermost AnteDecorator.
-		NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
+		NewGasWantedDecorator(options.FeeMarketKeeper, ethCfg),
 		NewEthEmitEventDecorator(options.EvmKeeper), // emit eth tx hash and index at the very last ante handler.
 	}
 	decorators = append(decorators, extra...)
 	return sdk.ChainAnteDecorators(decorators...)
 }
 
-func newCosmosAnteHandler(options HandlerOptions, extra ...sdk.AnteDecorator) sdk.AnteHandler {
+func newCosmosAnteHandler(ctx sdk.Context, options HandlerOptions, extra ...sdk.AnteDecorator) sdk.AnteHandler {
+	evmParams := options.EvmKeeper.GetParams(ctx)
+	evmDenom := evmParams.EvmDenom
+	chainID := options.EvmKeeper.ChainID()
+	chainCfg := evmParams.GetChainConfig()
+	ethCfg := chainCfg.EthereumConfig(chainID)
 	decorators := []sdk.AnteDecorator{
 		RejectMessagesDecorator{}, // reject MsgEthereumTxs
 		// disable the Msg types that cannot be included on an authz.MsgExec msgs field
@@ -94,7 +105,7 @@ func newCosmosAnteHandler(options HandlerOptions, extra ...sdk.AnteDecorator) sd
 		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),
-		NewMinGasPriceDecorator(options.FeeMarketKeeper, options.EvmKeeper),
+		NewMinGasPriceDecorator(options.FeeMarketKeeper, evmDenom),
 		ante.NewValidateMemoDecorator(options.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker),
@@ -105,7 +116,7 @@ func newCosmosAnteHandler(options HandlerOptions, extra ...sdk.AnteDecorator) sd
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
-		NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
+		NewGasWantedDecorator(options.FeeMarketKeeper, ethCfg),
 	}
 	decorators = append(decorators, extra...)
 	return sdk.ChainAnteDecorators(decorators...)

--- a/app/ante/interfaces.go
+++ b/app/ante/interfaces.go
@@ -22,8 +22,6 @@ import (
 	tx "github.com/cosmos/cosmos-sdk/types/tx"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/evmos/ethermint/x/evm/statedb"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
@@ -42,13 +40,9 @@ type EVMKeeper interface {
 	statedb.Keeper
 	DynamicFeeEVMKeeper
 
-	NewEVM(ctx sdk.Context, msg core.Message, cfg *statedb.EVMConfig, tracer vm.EVMLogger, stateDB vm.StateDB,
-		customContracts []vm.PrecompiledContract) *vm.EVM
 	DeductTxCostsFromUserBalance(ctx sdk.Context, fees sdk.Coins, from common.Address) error
-	GetEVMDenomBalance(ctx sdk.Context, addr common.Address) *big.Int
 	ResetTransientGasUsed(ctx sdk.Context)
 	GetTxIndexTransient(ctx sdk.Context) uint64
-	GetParams(ctx sdk.Context) evmtypes.Params
 }
 
 type protoTxProvider interface {

--- a/app/ante/setup_test.go
+++ b/app/ante/setup_test.go
@@ -5,7 +5,9 @@ import (
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/evmos/ethermint/app/ante"
+	"github.com/evmos/ethermint/tests"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 )
 
@@ -39,4 +41,64 @@ func (suite AnteTestSuite) TestEthSetupContextDecorator() {
 			}
 		})
 	}
+}
+
+func (suite AnteTestSuite) TestValidateBasicDecorator() {
+	addr, privKey := tests.NewAddrKey()
+
+	signedTx := evmtypes.NewTxContract(suite.app.EvmKeeper.ChainID(), 1, big.NewInt(10), 1000, big.NewInt(1), nil, nil, nil, nil)
+	signedTx.From = addr.Hex()
+	err := signedTx.Sign(suite.ethSigner, tests.NewSigner(privKey))
+	suite.Require().NoError(err)
+
+	unprotectedTx := evmtypes.NewTxContract(nil, 1, big.NewInt(10), 1000, big.NewInt(1), nil, nil, nil, nil)
+	unprotectedTx.From = addr.Hex()
+	err = unprotectedTx.Sign(ethtypes.HomesteadSigner{}, tests.NewSigner(privKey))
+	suite.Require().NoError(err)
+	tmTx, err := unprotectedTx.BuildTx(suite.clientCtx.TxConfig.NewTxBuilder(), evmtypes.DefaultEVMDenom)
+	suite.Require().NoError(err)
+
+	testCases := []struct {
+		name                string
+		tx                  sdk.Tx
+		allowUnprotectedTxs bool
+		reCheckTx           bool
+		expPass             bool
+	}{
+		{"invalid transaction type", &invalidTx{}, false, false, false},
+		{
+			"invalid sender",
+			evmtypes.NewTx(suite.app.EvmKeeper.ChainID(), 1, &addr, big.NewInt(10), 1000, big.NewInt(1), nil, nil, nil, nil),
+			true,
+			false,
+			false,
+		},
+		{"invalid, reject unprotected txs", tmTx, false, false, false},
+		{"successful, allow unprotected txs", tmTx, true, false, true},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.evmParamsOption = func(params *evmtypes.Params) {
+				params.AllowUnprotectedTxs = tc.allowUnprotectedTxs
+			}
+			suite.SetupTest()
+
+			evmParams := suite.app.EvmKeeper.GetParams(suite.ctx)
+			chainID := suite.app.EvmKeeper.ChainID()
+			chainCfg := evmParams.GetChainConfig()
+			ethCfg := chainCfg.EthereumConfig(chainID)
+			baseFee := suite.app.EvmKeeper.GetBaseFee(suite.ctx, ethCfg)
+
+			dec := ante.NewEthValidateBasicDecorator(&evmParams, baseFee)
+			_, err := dec.AnteHandle(suite.ctx.WithIsReCheckTx(tc.reCheckTx), tc.tx, false, NextFn)
+
+			if tc.expPass {
+				suite.Require().NoError(err)
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+	suite.evmParamsOption = nil
 }

--- a/app/ante/sigverify.go
+++ b/app/ante/sigverify.go
@@ -22,19 +22,18 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 )
 
 // EthSigVerificationDecorator validates an ethereum signatures
 type EthSigVerificationDecorator struct {
-	evmKeeper EVMKeeper
+	ethCfg *params.ChainConfig
 }
 
 // NewEthSigVerificationDecorator creates a new EthSigVerificationDecorator
-func NewEthSigVerificationDecorator(ek EVMKeeper) EthSigVerificationDecorator {
-	return EthSigVerificationDecorator{
-		evmKeeper: ek,
-	}
+func NewEthSigVerificationDecorator(ethCfg *params.ChainConfig) EthSigVerificationDecorator {
+	return EthSigVerificationDecorator{ethCfg}
 }
 
 // AnteHandle validates checks that the registered chain id is the same as the one on the message, and
@@ -43,12 +42,8 @@ func NewEthSigVerificationDecorator(ek EVMKeeper) EthSigVerificationDecorator {
 // Failure in RecheckTx will prevent tx to be included into block, especially when CheckTx succeed, in which case user
 // won't see the error message.
 func (esvd EthSigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	chainID := esvd.evmKeeper.ChainID()
-	evmParams := esvd.evmKeeper.GetParams(ctx)
-	chainCfg := evmParams.GetChainConfig()
-	ethCfg := chainCfg.EthereumConfig(chainID)
 	blockNum := big.NewInt(ctx.BlockHeight())
-	signer := ethtypes.MakeSigner(ethCfg, blockNum)
+	signer := ethtypes.MakeSigner(esvd.ethCfg, blockNum)
 
 	for _, msg := range tx.GetMsgs() {
 		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
@@ -56,14 +51,7 @@ func (esvd EthSigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, s
 			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
 		}
 
-		allowUnprotectedTxs := evmParams.GetAllowUnprotectedTxs()
 		ethTx := msgEthTx.AsTransaction()
-		if !allowUnprotectedTxs && !ethTx.Protected() {
-			return ctx, errorsmod.Wrapf(
-				errortypes.ErrNotSupported,
-				"rejected unprotected Ethereum transaction. Please EIP155 sign your transaction to protect it against replay-attacks")
-		}
-
 		sender, err := signer.Sender(ethTx)
 		if err != nil {
 			return ctx, errorsmod.Wrapf(


### PR DESCRIPTION
## Description

Solution:
- refactor the decorators and share the result
- move unprotected tx check to ValidateBasic (sigverify decorator could be removed in future PRs, see https://github.com/crypto-org-chain/ethermint/issues/355)

## Benchmark Results

The `BenchmarkERC20Transfer` in cronos repo.

```
goos: darwin
goarch: amd64
pkg: github.com/crypto-org-chain/cronos/v2/app
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                         │ /tmp/before.txt │           /tmp/after.txt           │
                         │     sec/op      │    sec/op     vs base              │
ERC20Transfer/memdb-12       654.9m ±   5%   612.9m ± 19%       ~ (p=0.132 n=6)
ERC20Transfer/leveldb-12     653.6m ± 150%   700.5m ± 18%       ~ (p=0.394 n=6)
ERC20Transfer/memiavl-12     627.6m ±  83%   604.1m ± 28%  -3.75% (p=0.041 n=6)
geomean                      645.3m          637.7m        -1.17%

                         │ /tmp/before.txt │           /tmp/after.txt            │
                         │      B/op       │     B/op      vs base               │
ERC20Transfer/memdb-12        203.8Mi ± 0%   176.4Mi ± 0%  -13.43% (p=0.002 n=6)
ERC20Transfer/leveldb-12      205.5Mi ± 0%   178.2Mi ± 0%  -13.30% (p=0.002 n=6)
ERC20Transfer/memiavl-12      198.4Mi ± 0%   171.0Mi ± 0%  -13.79% (p=0.002 n=6)
geomean                       202.5Mi        175.2Mi       -13.51%

                         │ /tmp/before.txt │           /tmp/after.txt           │
                         │    allocs/op    │  allocs/op   vs base               │
ERC20Transfer/memdb-12         3.284M ± 0%   2.802M ± 0%  -14.65% (p=0.002 n=6)
ERC20Transfer/leveldb-12       3.282M ± 0%   2.801M ± 0%  -14.65% (p=0.002 n=6)
ERC20Transfer/memiavl-12       3.228M ± 0%   2.747M ± 0%  -14.90% (p=0.002 n=6)
geomean                        3.264M        2.783M       -14.74%
```

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
