### PR TITLE
Problem: filter rule for eth_getLogs is not aligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (rpc) [#401](https://github.com/crypto-org-chain/ethermint/pull/401) Align max nextBaseFee with minGasPrice in eth_feeHistory.
 - (ante) [#404](https://github.com/crypto-org-chain/ethermint/pull/404) Correct priority under recheck mode.
 - (evm) [#405](https://github.com/crypto-org-chain/ethermint/pull/405) Avoid duplicate cache events emitted from evm hooks.
+- (rpc) [#406](https://github.com/crypto-org-chain/ethermint/pull/406) Align filter rule for eth_getLogs when toBlock is newer than latest.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (rpc) [#401](https://github.com/crypto-org-chain/ethermint/pull/401) Align max nextBaseFee with minGasPrice in eth_feeHistory.
 - (ante) [#404](https://github.com/crypto-org-chain/ethermint/pull/404) Correct priority under recheck mode.
 - (evm) [#405](https://github.com/crypto-org-chain/ethermint/pull/405) Avoid duplicate cache events emitted from evm hooks.
-- (rpc) [#406](https://github.com/crypto-org-chain/ethermint/pull/406) Align filter rule for eth_getLogs when toBlock is newer than latest.
+- (rpc) [#406](https://github.com/crypto-org-chain/ethermint/pull/406) Align filter rule for eth_getLogs when toBlock is newer than latest or extract error occurs.
 
 ### Improvements
 

--- a/rpc/namespaces/ethereum/eth/filters/filters.go
+++ b/rpc/namespaces/ethereum/eth/filters/filters.go
@@ -108,9 +108,6 @@ const (
 // Logs searches the blockchain for matching log entries, returning all from the
 // first block that contains matches, updating the start of the filter accordingly.
 func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*ethtypes.Log, error) {
-	logs := []*ethtypes.Log{}
-	var err error
-
 	// If we're doing singleton block filtering, execute and return
 	if f.criteria.BlockHash != nil && *f.criteria.BlockHash != (common.Hash{}) {
 		resBlock, err := f.backend.TendermintBlockByHash(*f.criteria.BlockHash)
@@ -121,7 +118,7 @@ func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*eth
 		blockRes, err := f.backend.TendermintBlockResultByNumber(&resBlock.Block.Height)
 		if err != nil {
 			f.logger.Debug("failed to fetch block result from Tendermint", "height", resBlock.Block.Height, "error", err.Error())
-			return logs, nil
+			return nil, nil
 		}
 
 		bloom, err := f.backend.BlockBloom(blockRes)
@@ -168,6 +165,7 @@ func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*eth
 
 	from := f.criteria.FromBlock.Int64()
 	to := f.criteria.ToBlock.Int64()
+	logs := []*ethtypes.Log{}
 
 	for height := from; height <= to; height++ {
 		blockRes, err := f.backend.TendermintBlockResultByNumber(&height)
@@ -178,17 +176,17 @@ func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*eth
 
 		bloom, err := f.backend.BlockBloom(blockRes)
 		if err != nil {
-			return nil, err
+			return logs, err
 		}
 
 		filtered, err := f.blockLogs(blockRes, bloom)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to fetch block by number %d", height)
+			return logs, errors.Wrapf(err, "failed to fetch block by number %d", height)
 		}
 
 		// check logs limit
 		if len(logs)+len(filtered) > logLimit {
-			return nil, fmt.Errorf("query returned more than %d results", logLimit)
+			return logs, fmt.Errorf("query returned more than %d results", logLimit)
 		}
 		logs = append(logs, filtered...)
 	}

--- a/rpc/namespaces/ethereum/eth/filters/filters.go
+++ b/rpc/namespaces/ethereum/eth/filters/filters.go
@@ -121,7 +121,7 @@ func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*eth
 		blockRes, err := f.backend.TendermintBlockResultByNumber(&resBlock.Block.Height)
 		if err != nil {
 			f.logger.Debug("failed to fetch block result from Tendermint", "height", resBlock.Block.Height, "error", err.Error())
-			return nil, nil
+			return logs, nil
 		}
 
 		bloom, err := f.backend.BlockBloom(blockRes)
@@ -173,7 +173,7 @@ func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*eth
 		blockRes, err := f.backend.TendermintBlockResultByNumber(&height)
 		if err != nil {
 			f.logger.Debug("failed to fetch block result from Tendermint", "height", height, "error", err.Error())
-			return nil, nil
+			return logs, nil
 		}
 
 		bloom, err := f.backend.BlockBloom(blockRes)

--- a/tests/integration_tests/test_filters.py
+++ b/tests/integration_tests/test_filters.py
@@ -78,6 +78,7 @@ def test_get_logs_by_topic(cluster):
     tx = contract.functions.setGreeting("world").build_transaction()
     receipt = send_transaction(w3, tx)
     assert receipt.status == 1
+    start = w3.eth.get_block_number()
 
     # The getLogs method under the hood works as a filter
     # with the specified topics and a block range.
@@ -94,6 +95,17 @@ def test_get_logs_by_topic(cluster):
     w3_wait_for_new_blocks(w3, 2)
     logs = w3.eth.get_logs({"topics": [topic.hex()]})
     assert len(logs) == 0
+
+    # return logs when to block is newer than latest
+    end = start + 2000
+    logs = w3.eth.get_logs(
+        {
+            "fromBlock": hex(start),
+            "toBlock": hex(end),
+            "address": [contract.address],
+        }
+    )
+    assert len(logs) > 0
 
 
 def test_pending_transaction_filter(cluster):


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

when to block is [newer](https://github.com/ethereum/go-ethereum/blob/16ce7bf50fa71c907d1dc6504ed32a9161e71351/eth/filters/filter.go#L273) than latest or extract [error](https://github.com/ethereum/go-ethereum/blob/16ce7bf50fa71c907d1dc6504ed32a9161e71351/eth/filters/filter.go#L169) occurs, return the extracted logs instead

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
