### PR TITLE
Problem: trace response for failed tx is not aligned with go-ethereum (backport #441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (rpc) [#434](https://github.com/crypto-org-chain/ethermint/pull/434) No need gasPrice when patch gasUsed for `eth_getTransactionReceipt`.
 * (feemarket) [#433](https://github.com/crypto-org-chain/ethermint/pull/433) Fix sdk int conversion panic with baseFee.
-* (rpc) [#439](https://github.com/crypto-org-chain/ethermint/pull/439) Align trace response for failed tx with go-ethereum.
+* (rpc) [#439](https://github.com/crypto-org-chain/ethermint/pull/439), [#441](https://github.com/crypto-org-chain/ethermint/pull/441) Align trace response for failed tx with go-ethereum.
 
 ### Features
 

--- a/tests/integration_tests/test_tracers.py
+++ b/tests/integration_tests/test_tracers.py
@@ -15,6 +15,7 @@ from .expected_constants import (
 from .utils import (
     ADDRS,
     CONTRACTS,
+    create_contract_transaction,
     deploy_contract,
     derive_new_account,
     derive_random_account,
@@ -24,10 +25,9 @@ from .utils import (
 )
 
 
-def test_trace_error(ethermint, geth):
+def test_out_of_gas_error(ethermint, geth):
     method = "debug_traceTransaction"
     tracer = {"tracer": "callTracer"}
-    tracers = [[tracer]]
     iterations = 1
     acc = derive_random_account()
 
@@ -39,12 +39,36 @@ def test_trace_error(ethermint, geth):
         tx_hash = send_transaction(w3, tx)["transactionHash"].hex()
         res = []
         call = w3.provider.make_request
-        with ThreadPoolExecutor(len(tracers)) as exec:
-            params = [([tx_hash] + cfg) for cfg in tracers]
-            exec_map = exec.map(call, itertools.repeat(method), params)
-            for resp in exec_map:
-                assert "out of gas" in resp["result"]["error"], resp
-                res = [json.dumps(resp["result"], sort_keys=True)]
+        resp = call(method, [tx_hash, tracer])
+        assert "out of gas" in resp["result"]["error"], resp
+        res = [json.dumps(resp["result"], sort_keys=True)]
+        return res
+
+    providers = [ethermint.w3, geth.w3]
+    with ThreadPoolExecutor(len(providers)) as exec:
+        tasks = [exec.submit(process, w3) for w3 in providers]
+        res = [future.result() for future in as_completed(tasks)]
+        assert len(res) == len(providers)
+        assert res[0] == res[-1], res
+
+
+def test_storage_out_of_gas_error(ethermint, geth):
+    method = "debug_traceTransaction"
+    tracer = {"tracer": "callTracer"}
+    acc = derive_new_account(8)
+
+    def process(w3):
+        # fund new sender to deploy contract with same address
+        fund_acc(w3, acc)
+        tx = create_contract_transaction(w3, CONTRACTS["TestMessageCall"], key=acc.key)
+        tx["gas"] = 210000
+        tx_hash = send_transaction(w3, tx, key=acc.key)["transactionHash"].hex()
+        res = []
+        call = w3.provider.make_request
+        resp = call(method, [tx_hash, tracer])
+        msg = "contract creation code storage out of gas"
+        assert msg in resp["result"]["error"], resp
+        res = [json.dumps(resp["result"], sort_keys=True)]
         return res
 
     providers = [ethermint.w3, geth.w3]

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -713,7 +713,7 @@ func (k *Keeper) prepareTrace(
 	}
 
 	if res.VmError != "" {
-		if res.VmError != vm.ErrExecutionReverted.Error() && res.VmError != vm.ErrOutOfGas.Error() {
+		if res.VmError == vm.ErrInsufficientBalance.Error() {
 			return nil, 0, status.Error(codes.Internal, res.VmError)
 		}
 	}


### PR DESCRIPTION
… (#441)

* Problem: trace response for failed tx is not aligned with go-ethereum

align for more errors, https://github.com/ethereum/go-ethereum/blob/release/1.12/core/vm/errors.go#L24

* cleanup

* diff group

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
