### PR TITLE
Problem: params not cached in object store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (evm) [#447](https://github.com/crypto-org-chain/ethermint/pull/447) Deduct fee through virtual bank transfer.
 * (evm) [#448](https://github.com/crypto-org-chain/ethermint/pull/448) Refactor the evm transfer to be more efficient.
 * (evm) [#450](https://github.com/crypto-org-chain/ethermint/pull/450) Refactor transient stores to be compatible with parallel tx execution.
+* (evm) [#454](https://github.com/crypto-org-chain/ethermint/pull/454) Migrate transient stores to object stores.
 
 ### State Machine Breaking
 

--- a/app/app.go
+++ b/app/app.go
@@ -331,9 +331,9 @@ func NewEthermintApp(
 	)
 
 	// Add the EVM transient store key
-	tkeys := storetypes.NewTransientStoreKeys(paramstypes.TStoreKey, evmtypes.TransientKey)
+	tkeys := storetypes.NewTransientStoreKeys(paramstypes.TStoreKey)
 	memKeys := storetypes.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
-	okeys := storetypes.NewObjectStoreKeys(banktypes.ObjectStoreKey)
+	okeys := storetypes.NewObjectStoreKeys(banktypes.ObjectStoreKey, evmtypes.ObjectStoreKey, feemarkettypes.ObjectStoreKey)
 
 	// load state streaming if enabled
 	if err := bApp.RegisterStreamingServices(appOpts, keys); err != nil {
@@ -495,9 +495,8 @@ func NewEthermintApp(
 	feeMarketSs := app.GetSubspace(feemarkettypes.ModuleName)
 	app.FeeMarketKeeper = feemarketkeeper.NewKeeper(
 		appCodec,
-		runtime.NewKVStoreService(keys[feemarkettypes.StoreKey]),
 		authtypes.NewModuleAddress(govtypes.ModuleName),
-		keys[feemarkettypes.StoreKey],
+		keys[feemarkettypes.StoreKey], okeys[feemarkettypes.ObjectStoreKey],
 	)
 
 	// Set authority to x/gov module account to only expect the module account to update params
@@ -505,7 +504,7 @@ func NewEthermintApp(
 	app.EvmKeeper = evmkeeper.NewKeeper(
 		appCodec,
 		runtime.NewKVStoreService(keys[evmtypes.StoreKey]),
-		keys[evmtypes.StoreKey], tkeys[evmtypes.TransientKey], authtypes.NewModuleAddress(govtypes.ModuleName),
+		keys[evmtypes.StoreKey], okeys[evmtypes.ObjectStoreKey], authtypes.NewModuleAddress(govtypes.ModuleName),
 		app.AccountKeeper, app.BankKeeper, app.StakingKeeper, app.FeeMarketKeeper,
 		tracer,
 		nil,

--- a/x/evm/keeper/abci.go
+++ b/x/evm/keeper/abci.go
@@ -24,6 +24,10 @@ import (
 // BeginBlock sets the sdk Context and EIP155 chain id to the Keeper.
 func (k *Keeper) BeginBlock(ctx sdk.Context) error {
 	k.WithChainID(ctx)
+
+	// cache params object
+	_ = k.GetParams(ctx)
+
 	return nil
 }
 

--- a/x/evm/keeper/bloom.go
+++ b/x/evm/keeper/bloom.go
@@ -8,19 +8,19 @@ import (
 	"github.com/evmos/ethermint/x/evm/types"
 )
 
-func (k Keeper) SetTxBloom(ctx sdk.Context, bloom []byte) {
-	store := ctx.KVStore(k.transientKey)
-	store.Set(types.TransientBloomKey(ctx.TxIndex(), ctx.MsgIndex()), bloom)
+func (k Keeper) SetTxBloom(ctx sdk.Context, bloom *big.Int) {
+	store := ctx.ObjectStore(k.objectKey)
+	store.Set(types.ObjectBloomKey(ctx.TxIndex(), ctx.MsgIndex()), bloom)
 }
 
 func (k Keeper) CollectTxBloom(ctx sdk.Context) {
-	store := prefix.NewStore(ctx.KVStore(k.transientKey), types.KeyPrefixTransientBloom)
+	store := prefix.NewObjStore(ctx.ObjectStore(k.objectKey), types.KeyPrefixObjectBloom)
 	it := store.Iterator(nil, nil)
 	defer it.Close()
 
 	bloom := new(big.Int)
 	for ; it.Valid(); it.Next() {
-		bloom.Or(bloom, big.NewInt(0).SetBytes(it.Value()))
+		bloom.Or(bloom, it.Value().(*big.Int))
 	}
 
 	k.EmitBlockBloomEvent(ctx, bloom.Bytes())

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -200,7 +200,7 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 
 	// Compute block bloom filter
 	if len(logs) > 0 {
-		k.SetTxBloom(tmpCtx, ethtypes.LogsBloom(logs))
+		k.SetTxBloom(tmpCtx, new(big.Int).SetBytes(ethtypes.LogsBloom(logs)))
 	}
 
 	var contractAddr common.Address

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -30,9 +30,9 @@ const (
 	// The EVM module should use a prefix store.
 	StoreKey = ModuleName
 
-	// TransientKey is the key to access the EVM transient store, that is reset
+	// ObjectStoreKey is the key to access the EVM object store, that is reset
 	// during the Commit phase.
-	TransientKey = "transient_" + ModuleName
+	ObjectStoreKey = "object:" + ModuleName
 
 	// RouterKey uses module name for routing
 	RouterKey = ModuleName
@@ -45,10 +45,11 @@ const (
 	prefixParams
 )
 
-// prefix bytes for the EVM transient store
+// prefix bytes for the EVM object store
 const (
-	prefixTransientBloom = iota + 1
-	prefixTransientGasUsed
+	prefixObjectBloom = iota + 1
+	prefixObjectGasUsed
+	prefixObjectParams
 )
 
 // KVStore key prefixes
@@ -58,10 +59,11 @@ var (
 	KeyPrefixParams  = []byte{prefixParams}
 )
 
-// Transient Store key prefixes
+// Object Store key prefixes
 var (
-	KeyPrefixTransientBloom   = []byte{prefixTransientBloom}
-	KeyPrefixTransientGasUsed = []byte{prefixTransientGasUsed}
+	KeyPrefixObjectBloom   = []byte{prefixObjectBloom}
+	KeyPrefixObjectGasUsed = []byte{prefixObjectGasUsed}
+	KeyPrefixObjectParams  = []byte{prefixObjectParams}
 )
 
 // AddressStoragePrefix returns a prefix to iterate over a given account storage.
@@ -74,16 +76,16 @@ func StateKey(address common.Address, key []byte) []byte {
 	return append(AddressStoragePrefix(address), key...)
 }
 
-func TransientGasUsedKey(txIndex int) []byte {
-	var key [9]byte
-	key[0] = prefixTransientGasUsed
+func ObjectGasUsedKey(txIndex int) []byte {
+	var key [1 + 8]byte
+	key[0] = prefixObjectGasUsed
 	binary.BigEndian.PutUint64(key[1:], uint64(txIndex))
 	return key[:]
 }
 
-func TransientBloomKey(txIndex, msgIndex int) []byte {
+func ObjectBloomKey(txIndex, msgIndex int) []byte {
 	var key [1 + 8 + 8]byte
-	key[0] = prefixTransientBloom
+	key[0] = prefixObjectBloom
 	binary.BigEndian.PutUint64(key[1:], uint64(txIndex))
 	binary.BigEndian.PutUint64(key[9:], uint64(msgIndex))
 	return key[:]

--- a/x/feemarket/keeper/keeper.go
+++ b/x/feemarket/keeper/keeper.go
@@ -18,7 +18,6 @@ package keeper
 import (
 	"math/big"
 
-	corestoretypes "cosmossdk.io/core/store"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -33,10 +32,9 @@ var KeyPrefixBaseFeeV1 = []byte{2}
 // Keeper grants access to the Fee Market module state.
 type Keeper struct {
 	// Protobuf codec
-	cdc          codec.BinaryCodec
-	storeService corestoretypes.KVStoreService
+	cdc codec.BinaryCodec
 	// Store key required for the Fee Market Prefix KVStore.
-	storeKey storetypes.StoreKey
+	storeKey, objectKey storetypes.StoreKey
 	// the address capable of executing a MsgUpdateParams message. Typically, this should be the x/gov module account.
 	authority sdk.AccAddress
 }
@@ -44,9 +42,8 @@ type Keeper struct {
 // NewKeeper generates new fee market module keeper
 func NewKeeper(
 	cdc codec.BinaryCodec,
-	storeService corestoretypes.KVStoreService,
 	authority sdk.AccAddress,
-	storeKey storetypes.StoreKey,
+	storeKey, objectKey storetypes.StoreKey,
 ) Keeper {
 	// ensure authority account is correctly formatted
 	if err := sdk.VerifyAddressFormat(authority); err != nil {
@@ -54,10 +51,10 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		cdc:          cdc,
-		storeService: storeService,
-		storeKey:     storeKey,
-		authority:    authority,
+		cdc:       cdc,
+		storeKey:  storeKey,
+		objectKey: objectKey,
+		authority: authority,
 	}
 }
 

--- a/x/feemarket/types/keys.go
+++ b/x/feemarket/types/keys.go
@@ -25,6 +25,9 @@ const (
 
 	// RouterKey uses module name for routing
 	RouterKey = ModuleName
+
+	// ObjectStoreKey is the key to access the Fee Market object store
+	ObjectStoreKey = "object:" + ModuleName
 )
 
 // prefix bytes for the feemarket persistent store
@@ -33,7 +36,17 @@ const (
 	deprecatedPrefixBaseFee // unused
 )
 
+// prefix bytes for the feemarket object store
+const (
+	prefixObjectParams = iota + 1
+)
+
 // KVStore key prefixes
 var (
 	KeyPrefixBlockGasWanted = []byte{prefixBlockGasWanted}
+)
+
+// Object store key prefixes
+var (
+	KeyPrefixObjectParams = []byte{prefixObjectParams}
 )


### PR DESCRIPTION
Solution:
- save the cost of repeated encoding/decoding during the block execution
- also migrate existing transient stores to object stores

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
