### PR TITLE
Problem: hash in subscribe newHeads differs from eth_getBlockByNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (rpc) [#488](https://github.com/crypto-org-chain/ethermint/pull/488) Fix handling of pending transactions related APIs.
 * (rpc) [#501](https://github.com/crypto-org-chain/ethermint/pull/501) Avoid invalid chain id for signer error when rpc call before chain id set in BeginBlock.
 * (block-stm) [#510](https://github.com/crypto-org-chain/ethermint/pull/510) Include a fix to avoid nondeterministic account set when stm workers execute in parallel.
+* (rpc) [#521](https://github.com/crypto-org-chain/ethermint/pull/521) Align hash and miner in subscribe newHeads with eth_getBlockByNumber.
 
 ### Improvements
 

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -323,7 +323,7 @@ func (b *Backend) HeaderByNumber(blockNum rpctypes.BlockNumber) (*ethtypes.Heade
 	}
 	validator, err := b.getValidatorAccount(resBlock)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get validator account %w", err)
+		return nil, err
 	}
 	ethHeader := rpctypes.EthHeaderFromTendermint(resBlock.Block.Header, bloom, baseFee, validator)
 	return ethHeader, nil
@@ -356,7 +356,7 @@ func (b *Backend) HeaderByHash(blockHash common.Hash) (*ethtypes.Header, error) 
 	}
 	validator, err := b.getValidatorAccount(resBlock)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get validator account %w", err)
+		return nil, err
 	}
 	ethHeader := rpctypes.EthHeaderFromTendermint(resBlock.Block.Header, bloom, baseFee, validator)
 	return ethHeader, nil
@@ -510,7 +510,7 @@ func (b *Backend) EthBlockFromTendermintBlock(
 	}
 	validator, err := b.getValidatorAccount(resBlock)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get validator account %w", err)
+		return nil, err
 	}
 	ethHeader := rpctypes.EthHeaderFromTendermint(block.Header, bloom, baseFee, validator)
 	msgs := b.EthMsgsFromTendermintBlock(resBlock, blockRes)

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -321,8 +321,11 @@ func (b *Backend) HeaderByNumber(blockNum rpctypes.BlockNumber) (*ethtypes.Heade
 		// handle the error for pruned node.
 		b.logger.Error("failed to fetch Base Fee from prunned block. Check node prunning configuration", "height", resBlock.Block.Height, "error", err)
 	}
-
-	ethHeader := rpctypes.EthHeaderFromTendermint(resBlock.Block.Header, bloom, baseFee)
+	validator, err := b.getValidatorAccount(resBlock)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validator account %w", err)
+	}
+	ethHeader := rpctypes.EthHeaderFromTendermint(resBlock.Block.Header, bloom, baseFee, validator)
 	return ethHeader, nil
 }
 
@@ -351,8 +354,11 @@ func (b *Backend) HeaderByHash(blockHash common.Hash) (*ethtypes.Header, error) 
 		// handle the error for pruned node.
 		b.logger.Error("failed to fetch Base Fee from prunned block. Check node prunning configuration", "height", resBlock.Block.Height, "error", err)
 	}
-
-	ethHeader := rpctypes.EthHeaderFromTendermint(resBlock.Block.Header, bloom, baseFee)
+	validator, err := b.getValidatorAccount(resBlock)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validator account %w", err)
+	}
+	ethHeader := rpctypes.EthHeaderFromTendermint(resBlock.Block.Header, bloom, baseFee, validator)
 	return ethHeader, nil
 }
 
@@ -502,8 +508,11 @@ func (b *Backend) EthBlockFromTendermintBlock(
 		// handle error for pruned node and log
 		b.logger.Error("failed to fetch Base Fee from prunned block. Check node prunning configuration", "height", height, "error", err)
 	}
-
-	ethHeader := rpctypes.EthHeaderFromTendermint(block.Header, bloom, baseFee)
+	validator, err := b.getValidatorAccount(resBlock)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validator account %w", err)
+	}
+	ethHeader := rpctypes.EthHeaderFromTendermint(block.Header, bloom, baseFee, validator)
 	msgs := b.EthMsgsFromTendermintBlock(resBlock, blockRes)
 
 	txs := make([]*ethtypes.Transaction, len(msgs))

--- a/rpc/backend/call_tx_test.go
+++ b/rpc/backend/call_tx_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -22,6 +23,7 @@ func (suite *BackendTestSuite) TestResend() {
 	gasPrice := new(hexutil.Big)
 	toAddr := tests.GenerateAddress()
 	chainID := (*hexutil.Big)(suite.backend.chainID)
+	validator := sdk.AccAddress(tests.GenerateAddress().Bytes())
 	callArgs := evmtypes.TransactionArgs{
 		From:                 nil,
 		To:                   &toAddr,
@@ -67,6 +69,7 @@ func (suite *BackendTestSuite) TestResend() {
 				RegisterBlock(client, 1, nil)
 				RegisterBlockResults(client, 1)
 				RegisterBaseFeeDisabled(queryClient)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			evmtypes.TransactionArgs{
 				Nonce:   &txNonce,
@@ -89,6 +92,7 @@ func (suite *BackendTestSuite) TestResend() {
 				RegisterBlock(client, 1, nil)
 				RegisterBlockResults(client, 1)
 				RegisterBaseFee(queryClient, baseFee)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			evmtypes.TransactionArgs{
 				Nonce: &txNonce,
@@ -108,6 +112,7 @@ func (suite *BackendTestSuite) TestResend() {
 				RegisterBlock(client, 1, nil)
 				RegisterBlockResults(client, 1)
 				RegisterBaseFeeDisabled(queryClient)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			evmtypes.TransactionArgs{
 				Nonce:                &txNonce,
@@ -161,6 +166,7 @@ func (suite *BackendTestSuite) TestResend() {
 				RegisterBlock(client, 1, nil)
 				RegisterBlockResults(client, 1)
 				RegisterBaseFee(queryClient, baseFee)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			evmtypes.TransactionArgs{
 				Nonce:                &txNonce,
@@ -184,6 +190,7 @@ func (suite *BackendTestSuite) TestResend() {
 				RegisterBlock(client, 1, nil)
 				RegisterBlockResults(client, 1)
 				RegisterBaseFee(queryClient, baseFee)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			evmtypes.TransactionArgs{
 				Nonce:                &txNonce,
@@ -208,6 +215,7 @@ func (suite *BackendTestSuite) TestResend() {
 				RegisterParams(queryClient, &header, 1)
 				RegisterParamsWithoutHeader(queryClient, 1)
 				RegisterUnconfirmedTxsError(client, nil)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			evmtypes.TransactionArgs{
 				Nonce:                &txNonce,
@@ -236,6 +244,7 @@ func (suite *BackendTestSuite) TestResend() {
 				RegisterParams(queryClient, &header, 1)
 				RegisterParamsWithoutHeader(queryClient, 1)
 				RegisterUnconfirmedTxsEmpty(client, nil)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			evmtypes.TransactionArgs{
 				Nonce:                &txNonce,
@@ -437,6 +446,7 @@ func (suite *BackendTestSuite) TestDoCall() {
 
 func (suite *BackendTestSuite) TestGasPrice() {
 	defaultGasPrice := (*hexutil.Big)(big.NewInt(1))
+	validator := sdk.AccAddress(tests.GenerateAddress().Bytes())
 
 	testCases := []struct {
 		name         string
@@ -456,6 +466,7 @@ func (suite *BackendTestSuite) TestGasPrice() {
 				RegisterBlock(client, 1, nil)
 				RegisterBlockResults(client, 1)
 				RegisterBaseFee(queryClient, sdkmath.NewInt(1))
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			defaultGasPrice,
 			true,
@@ -472,6 +483,7 @@ func (suite *BackendTestSuite) TestGasPrice() {
 				RegisterBlock(client, 1, nil)
 				RegisterBlockResults(client, 1)
 				RegisterBaseFee(queryClient, sdkmath.NewInt(1))
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			defaultGasPrice,
 			false,

--- a/rpc/backend/evm_query_client_test.go
+++ b/rpc/backend/evm_query_client_test.go
@@ -206,6 +206,13 @@ func RegisterValidatorAccount(queryClient *mocks.EVMQueryClient, validator sdk.A
 		Return(&evmtypes.QueryValidatorAccountResponse{AccountAddress: validator.String()}, nil)
 }
 
+func RegisterValidatorAccountWithConsAddress(queryClient *mocks.EVMQueryClient, validator sdk.AccAddress, consAddress string) {
+	queryClient.On("ValidatorAccount", rpc.ContextWithHeight(1), &evmtypes.QueryValidatorAccountRequest{
+		ConsAddress: consAddress,
+	}).
+		Return(&evmtypes.QueryValidatorAccountResponse{AccountAddress: validator.String()}, nil)
+}
+
 func RegisterValidatorAccountError(queryClient *mocks.EVMQueryClient) {
 	queryClient.On("ValidatorAccount", rpc.ContextWithHeight(1), &evmtypes.QueryValidatorAccountRequest{}).
 		Return(nil, status.Error(codes.InvalidArgument, "empty request"))

--- a/rpc/backend/sign_tx_test.go
+++ b/rpc/backend/sign_tx_test.go
@@ -35,8 +35,8 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 		Gas:      &gas,
 		Nonce:    &nonce,
 	}
-
 	hash := common.Hash{}
+	validator := sdk.AccAddress(tests.GenerateAddress().Bytes())
 
 	testCases := []struct {
 		name         string
@@ -79,6 +79,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				RegisterBlock(client, 1, nil)
 				RegisterBlockResults(client, 1)
 				RegisterBaseFee(queryClient, baseFee)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			evmtypes.TransactionArgs{
 				From:     &from,
@@ -110,6 +111,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				txEncoder := suite.backend.clientCtx.TxConfig.TxEncoder()
 				txBytes, _ := txEncoder(tx)
 				RegisterBroadcastTxError(client, txBytes)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			callArgsDefault,
 			common.Hash{},
@@ -135,6 +137,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				txEncoder := suite.backend.clientCtx.TxConfig.TxEncoder()
 				txBytes, _ := txEncoder(tx)
 				RegisterBroadcastTx(client, txBytes)
+				RegisterValidatorAccount(queryClient, validator)
 			},
 			callArgsDefault,
 			hash,

--- a/rpc/backend/utils.go
+++ b/rpc/backend/utils.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/cometbft/cometbft/proto/tendermint/crypto"
 	"github.com/evmos/ethermint/rpc/types"
+	rpctypes "github.com/evmos/ethermint/rpc/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	feemarkettypes "github.com/evmos/ethermint/x/feemarket/types"
 )
@@ -316,4 +317,17 @@ func GetHexProofs(proof *crypto.ProofOps) []string {
 		proofs = append(proofs, proof)
 	}
 	return proofs
+}
+
+func (b *Backend) getValidatorAccount(resBlock *tmrpctypes.ResultBlock) (sdk.AccAddress, error) {
+	res, err := b.queryClient.ValidatorAccount(
+		rpctypes.ContextWithHeight(resBlock.Block.Header.Height),
+		&evmtypes.QueryValidatorAccountRequest{
+			ConsAddress: sdk.ConsAddress(resBlock.Block.Header.ProposerAddress).String(),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validator account %w", err)
+	}
+	return sdk.AccAddressFromBech32(res.AccountAddress)
 }

--- a/rpc/backend/utils.go
+++ b/rpc/backend/utils.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/cometbft/cometbft/proto/tendermint/crypto"
 	"github.com/evmos/ethermint/rpc/types"
-	rpctypes "github.com/evmos/ethermint/rpc/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	feemarkettypes "github.com/evmos/ethermint/x/feemarket/types"
 )
@@ -321,7 +320,7 @@ func GetHexProofs(proof *crypto.ProofOps) []string {
 
 func (b *Backend) getValidatorAccount(resBlock *tmrpctypes.ResultBlock) (sdk.AccAddress, error) {
 	res, err := b.queryClient.ValidatorAccount(
-		rpctypes.ContextWithHeight(resBlock.Block.Header.Height),
+		types.ContextWithHeight(resBlock.Block.Header.Height),
 		&evmtypes.QueryValidatorAccountRequest{
 			ConsAddress: sdk.ConsAddress(resBlock.Block.Header.ProposerAddress).String(),
 		},

--- a/rpc/stream/rpc.go
+++ b/rpc/stream/rpc.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/evmos/ethermint/rpc/types"
-	rpctypes "github.com/evmos/ethermint/rpc/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"google.golang.org/grpc"
 )
@@ -46,7 +45,9 @@ type RPCHeader struct {
 	Hash      common.Hash
 }
 
-type validatorAccountFunc func(ctx context.Context, in *evmtypes.QueryValidatorAccountRequest, opts ...grpc.CallOption) (*evmtypes.QueryValidatorAccountResponse, error)
+type validatorAccountFunc func(
+	ctx context.Context, in *evmtypes.QueryValidatorAccountRequest, opts ...grpc.CallOption,
+) (*evmtypes.QueryValidatorAccountResponse, error)
 
 // RPCStream provides data streams for newHeads, logs, and pendingTransactions.
 type RPCStream struct {
@@ -153,7 +154,7 @@ func (s *RPCStream) start(
 
 			baseFee := types.BaseFeeFromEvents(data.ResultFinalizeBlock.Events)
 			res, err := s.validatorAccount(
-				rpctypes.ContextWithHeight(data.Block.Height),
+				types.ContextWithHeight(data.Block.Height),
 				&evmtypes.QueryValidatorAccountRequest{
 					ConsAddress: sdk.ConsAddress(data.Block.Header.ProposerAddress).String(),
 				},

--- a/rpc/stream/rpc.go
+++ b/rpc/stream/rpc.go
@@ -14,7 +14,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/evmos/ethermint/rpc/types"
+	rpctypes "github.com/evmos/ethermint/rpc/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -44,6 +46,8 @@ type RPCHeader struct {
 	Hash      common.Hash
 }
 
+type validatorAccountFunc func(ctx context.Context, in *evmtypes.QueryValidatorAccountRequest, opts ...grpc.CallOption) (*evmtypes.QueryValidatorAccountResponse, error)
+
 // RPCStream provides data streams for newHeads, logs, and pendingTransactions.
 type RPCStream struct {
 	evtClient rpcclient.EventsClient
@@ -54,22 +58,25 @@ type RPCStream struct {
 	pendingTxStream *Stream[common.Hash]
 	logStream       *Stream[*ethtypes.Log]
 
-	wg sync.WaitGroup
+	wg               sync.WaitGroup
+	validatorAccount validatorAccountFunc
 }
 
 func NewRPCStreams(
 	evtClient rpcclient.EventsClient,
 	logger log.Logger,
 	txDecoder sdk.TxDecoder,
+	validatorAccount validatorAccountFunc,
 ) (*RPCStream, error) {
 	s := &RPCStream{
 		evtClient: evtClient,
 		logger:    logger,
 		txDecoder: txDecoder,
 
-		headerStream:    NewStream[RPCHeader](headerStreamSegmentSize, headerStreamCapacity),
-		pendingTxStream: NewStream[common.Hash](txStreamSegmentSize, txStreamCapacity),
-		logStream:       NewStream[*ethtypes.Log](logStreamSegmentSize, logStreamCapacity),
+		headerStream:     NewStream[RPCHeader](headerStreamSegmentSize, headerStreamCapacity),
+		pendingTxStream:  NewStream[common.Hash](txStreamSegmentSize, txStreamCapacity),
+		logStream:        NewStream[*ethtypes.Log](logStreamSegmentSize, logStreamCapacity),
+		validatorAccount: validatorAccount,
 	}
 
 	ctx := context.Background()
@@ -145,9 +152,23 @@ func (s *RPCStream) start(
 			}
 
 			baseFee := types.BaseFeeFromEvents(data.ResultFinalizeBlock.Events)
-
+			res, err := s.validatorAccount(
+				rpctypes.ContextWithHeight(data.Block.Height),
+				&evmtypes.QueryValidatorAccountRequest{
+					ConsAddress: sdk.ConsAddress(data.Block.Header.ProposerAddress).String(),
+				},
+			)
+			if err != nil {
+				s.logger.Error("failed to get validator account", "err", err)
+				continue
+			}
+			validator, err := sdk.AccAddressFromBech32(res.AccountAddress)
+			if err != nil {
+				s.logger.Error("failed to convert validator account", "err", err)
+				continue
+			}
 			// TODO: fetch bloom from events
-			header := types.EthHeaderFromTendermint(data.Block.Header, ethtypes.Bloom{}, baseFee)
+			header := types.EthHeaderFromTendermint(data.Block.Header, ethtypes.Bloom{}, baseFee, validator)
 			s.headerStream.Add(RPCHeader{EthHeader: header, Hash: common.BytesToHash(data.Block.Header.Hash())})
 
 		case ev, ok := <-chLogs:

--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -26,6 +26,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
@@ -63,16 +64,15 @@ func RawTxToEthTx(clientCtx client.Context, txBz tmtypes.Tx) ([]*evmtypes.MsgEth
 
 // EthHeaderFromTendermint is an util function that returns an Ethereum Header
 // from a tendermint Header.
-func EthHeaderFromTendermint(header tmtypes.Header, bloom ethtypes.Bloom, baseFee *big.Int) *ethtypes.Header {
+func EthHeaderFromTendermint(header tmtypes.Header, bloom ethtypes.Bloom, baseFee *big.Int, miner sdk.AccAddress) *ethtypes.Header {
 	txHash := ethtypes.EmptyRootHash
 	if len(header.DataHash) == 0 {
 		txHash = common.BytesToHash(header.DataHash)
 	}
-
 	return &ethtypes.Header{
 		ParentHash:  common.BytesToHash(header.LastBlockID.Hash.Bytes()),
 		UncleHash:   ethtypes.EmptyUncleHash,
-		Coinbase:    common.BytesToAddress(header.ProposerAddress),
+		Coinbase:    common.BytesToAddress(miner),
 		Root:        common.BytesToHash(header.AppHash),
 		TxHash:      txHash,
 		ReceiptHash: ethtypes.EmptyRootHash,

--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -385,18 +386,62 @@ func (api *pubSubAPI) subscribe(wsConn *wsConn, subID rpc.ID, params []interface
 	}
 }
 
+// https://github.com/ethereum/go-ethereum/blob/release/1.11/core/types/gen_header_json.go#L18
+type Header struct {
+	ParentHash common.Hash `json:"parentHash"       gencodec:"required"`
+	UncleHash  common.Hash `json:"sha3Uncles"       gencodec:"required"`
+	// update string avoid lost checksumed miner after MarshalText
+	Coinbase        string              `json:"miner"`
+	Root            common.Hash         `json:"stateRoot"        gencodec:"required"`
+	TxHash          common.Hash         `json:"transactionsRoot" gencodec:"required"`
+	ReceiptHash     common.Hash         `json:"receiptsRoot"     gencodec:"required"`
+	Bloom           ethtypes.Bloom      `json:"logsBloom"        gencodec:"required"`
+	Difficulty      *hexutil.Big        `json:"difficulty"       gencodec:"required"`
+	Number          *hexutil.Big        `json:"number"           gencodec:"required"`
+	GasLimit        hexutil.Uint64      `json:"gasLimit"         gencodec:"required"`
+	GasUsed         hexutil.Uint64      `json:"gasUsed"          gencodec:"required"`
+	Time            hexutil.Uint64      `json:"timestamp"        gencodec:"required"`
+	Extra           hexutil.Bytes       `json:"extraData"        gencodec:"required"`
+	MixDigest       common.Hash         `json:"mixHash"`
+	Nonce           ethtypes.BlockNonce `json:"nonce"`
+	BaseFee         *hexutil.Big        `json:"baseFeePerGas" rlp:"optional"`
+	WithdrawalsHash *common.Hash        `json:"withdrawalsRoot" rlp:"optional"`
+	//overwrite rlpHash
+	Hash common.Hash `json:"hash"`
+}
+
 func (api *pubSubAPI) subscribeNewHeads(wsConn *wsConn, subID rpc.ID) (context.CancelFunc, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	//nolint: errcheck
 	go api.events.HeaderStream().Subscribe(ctx, func(headers []stream.RPCHeader, _ int) error {
 		for _, header := range headers {
+			h := header.EthHeader
+			var enc Header
+			enc.ParentHash = h.ParentHash
+			enc.UncleHash = h.UncleHash
+			enc.Coinbase = h.Coinbase.Hex()
+			enc.Root = h.Root
+			enc.TxHash = h.TxHash
+			enc.ReceiptHash = h.ReceiptHash
+			enc.Bloom = h.Bloom
+			enc.Difficulty = (*hexutil.Big)(h.Difficulty)
+			enc.Number = (*hexutil.Big)(h.Number)
+			enc.GasLimit = hexutil.Uint64(h.GasLimit)
+			enc.GasUsed = hexutil.Uint64(h.GasUsed)
+			enc.Time = hexutil.Uint64(h.Time)
+			enc.Extra = h.Extra
+			enc.MixDigest = h.MixDigest
+			enc.Nonce = h.Nonce
+			enc.BaseFee = (*hexutil.Big)(h.BaseFee)
+			enc.WithdrawalsHash = h.WithdrawalsHash
+			enc.Hash = header.Hash
 			// write to ws conn
 			res := &SubscriptionNotification{
 				Jsonrpc: "2.0",
 				Method:  "eth_subscription",
 				Params: &SubscriptionResult{
 					Subscription: subID,
-					Result:       header.EthHeader,
+					Result:       enc,
 				},
 			}
 

--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -406,7 +406,7 @@ type Header struct {
 	Nonce           ethtypes.BlockNonce `json:"nonce"`
 	BaseFee         *hexutil.Big        `json:"baseFeePerGas" rlp:"optional"`
 	WithdrawalsHash *common.Hash        `json:"withdrawalsRoot" rlp:"optional"`
-	//overwrite rlpHash
+	// overwrite rlpHash
 	Hash common.Hash `json:"hash"`
 }
 

--- a/server/json_rpc.go
+++ b/server/json_rpc.go
@@ -32,6 +32,7 @@ import (
 	"github.com/evmos/ethermint/app/ante"
 	"github.com/evmos/ethermint/rpc"
 	"github.com/evmos/ethermint/rpc/stream"
+	rpctypes "github.com/evmos/ethermint/rpc/types"
 	"github.com/evmos/ethermint/server/config"
 	ethermint "github.com/evmos/ethermint/types"
 )
@@ -62,8 +63,9 @@ func StartJSONRPC(srvCtx *server.Context,
 
 	var rpcStream *stream.RPCStream
 	var err error
+	queryClient := rpctypes.NewQueryClient(clientCtx)
 	for i := 0; i < MaxRetry; i++ {
-		rpcStream, err = stream.NewRPCStreams(evtClient, logger, clientCtx.TxConfig.TxDecoder())
+		rpcStream, err = stream.NewRPCStreams(evtClient, logger, clientCtx.TxConfig.TxDecoder(), queryClient.ValidatorAccount)
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

instead of overwriting hash field, seems `SetFmtHash` in [txhash-v038x](https://github.com/cometbft/cometbft/compare/v0.38.x...anton/txhash-v038x)  also allow us align eth tx hash  in long term

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
