### PR TITLE
removed listener closing in gracefully shutdown json-rpc server

### DIFF
--- a/server/json_rpc.go
+++ b/server/json_rpc.go
@@ -151,7 +151,7 @@ func StartJSONRPC(
 			if err := httpSrv.Shutdown(context.Background()); err != nil {
 				logger.Error("failed to shutdown JSON-RPC server", "error", err.Error())
 			}
-			return err
+			return nil
 
 		case err := <-errCh:
 			if err == http.ErrServerClosed {

--- a/server/json_rpc.go
+++ b/server/json_rpc.go
@@ -151,7 +151,7 @@ func StartJSONRPC(
 			if err := httpSrv.Shutdown(context.Background()); err != nil {
 				logger.Error("failed to shutdown JSON-RPC server", "error", err.Error())
 			}
-			return ln.Close()
+			return err
 
 		case err := <-errCh:
 			if err == http.ErrServerClosed {


### PR DESCRIPTION
we don't need to close listener when call server.Shutdown, otherwise we will get an error