### PR TITLE
Problem: rpc stream overhead even if not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#533](https://github.com/crypto-org-chain/ethermint/pull/533) Bump cosmos-sdk to v0.50.10, cometbft to v0.38.13 and ibc-go to v8.5.1.
 * [#546](https://github.com/crypto-org-chain/ethermint/pull/546) Introduce `--async-check-tx` flag to run check-tx async with consensus.
 * [#549](https://github.com/crypto-org-chain/ethermint/pull/549) Support build without cgo.
-* [#]() Start event stream on demand.
+* [#551](https://github.com/crypto-org-chain/ethermint/pull/551) Start event stream on demand.
 
 ## v0.21.x-cronos
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#533](https://github.com/crypto-org-chain/ethermint/pull/533) Bump cosmos-sdk to v0.50.10, cometbft to v0.38.13 and ibc-go to v8.5.1.
 * [#546](https://github.com/crypto-org-chain/ethermint/pull/546) Introduce `--async-check-tx` flag to run check-tx async with consensus.
 * [#549](https://github.com/crypto-org-chain/ethermint/pull/549) Support build without cgo.
+* [#]() Start event stream on demand.
 
 ## v0.21.x-cronos
 

--- a/rpc/stream/rpc.go
+++ b/rpc/stream/rpc.go
@@ -51,6 +51,7 @@ type validatorAccountFunc func(
 ) (*evmtypes.QueryValidatorAccountResponse, error)
 
 // RPCStream provides data streams for newHeads, logs, and pendingTransactions.
+// it's only started on demand, so there's no overhead if the filter apis are not called at all.
 type RPCStream struct {
 	evtClient rpcclient.EventsClient
 	logger    log.Logger
@@ -69,23 +70,30 @@ func NewRPCStreams(
 	logger log.Logger,
 	txDecoder sdk.TxDecoder,
 	validatorAccount validatorAccountFunc,
-) (*RPCStream, error) {
-	s := &RPCStream{
-		evtClient: evtClient,
-		logger:    logger,
-		txDecoder: txDecoder,
-
-		headerStream:     NewStream[RPCHeader](headerStreamSegmentSize, headerStreamCapacity),
-		pendingTxStream:  NewStream[common.Hash](txStreamSegmentSize, txStreamCapacity),
-		logStream:        NewStream[*ethtypes.Log](logStreamSegmentSize, logStreamCapacity),
+) *RPCStream {
+	return &RPCStream{
+		evtClient:        evtClient,
+		logger:           logger,
+		txDecoder:        txDecoder,
 		validatorAccount: validatorAccount,
 	}
+}
+
+func (s *RPCStream) init() {
+	if s.headerStream != nil {
+		// already initialized
+		return
+	}
+
+	s.headerStream = NewStream[RPCHeader](headerStreamSegmentSize, headerStreamCapacity)
+	s.pendingTxStream = NewStream[common.Hash](txStreamSegmentSize, txStreamCapacity)
+	s.logStream = NewStream[*ethtypes.Log](logStreamSegmentSize, logStreamCapacity)
 
 	ctx := context.Background()
 
 	chBlocks, err := s.evtClient.Subscribe(ctx, streamSubscriberName, blockEvents, subscribBufferSize)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
 	chLogs, err := s.evtClient.Subscribe(ctx, streamSubscriberName, evmEvents, subscribBufferSize)
@@ -93,15 +101,18 @@ func NewRPCStreams(
 		if err := s.evtClient.UnsubscribeAll(context.Background(), streamSubscriberName); err != nil {
 			s.logger.Error("failed to unsubscribe", "err", err)
 		}
-		return nil, err
+		panic(err)
 	}
 
 	go s.start(&s.wg, chBlocks, chLogs)
-
-	return s, nil
 }
 
 func (s *RPCStream) Close() error {
+	if s.headerStream == nil {
+		// not initialized
+		return nil
+	}
+
 	if err := s.evtClient.UnsubscribeAll(context.Background(), streamSubscriberName); err != nil {
 		return err
 	}
@@ -110,20 +121,23 @@ func (s *RPCStream) Close() error {
 }
 
 func (s *RPCStream) HeaderStream() *Stream[RPCHeader] {
+	s.init()
 	return s.headerStream
 }
 
 func (s *RPCStream) PendingTxStream() *Stream[common.Hash] {
+	s.init()
 	return s.pendingTxStream
 }
 
 func (s *RPCStream) LogStream() *Stream[*ethtypes.Log] {
+	s.init()
 	return s.logStream
 }
 
 // ListenPendingTx is a callback passed to application to listen for pending transactions in CheckTx.
 func (s *RPCStream) ListenPendingTx(hash common.Hash) {
-	s.pendingTxStream.Add(hash)
+	s.PendingTxStream().Add(hash)
 }
 
 func (s *RPCStream) start(

--- a/rpc/stream/rpc.go
+++ b/rpc/stream/rpc.go
@@ -57,9 +57,12 @@ type RPCStream struct {
 	logger    log.Logger
 	txDecoder sdk.TxDecoder
 
-	headerStream    *Stream[RPCHeader]
+	// headerStream/logStream are backed by cometbft event subscription
+	headerStream *Stream[RPCHeader]
+	logStream    *Stream[*ethtypes.Log]
+
+	// pendingTxStream is backed by check-tx ante handler
 	pendingTxStream *Stream[common.Hash]
-	logStream       *Stream[*ethtypes.Log]
 
 	wg               sync.WaitGroup
 	validatorAccount validatorAccountFunc
@@ -76,17 +79,17 @@ func NewRPCStreams(
 		logger:           logger,
 		txDecoder:        txDecoder,
 		validatorAccount: validatorAccount,
+		pendingTxStream:  NewStream[common.Hash](txStreamSegmentSize, txStreamCapacity),
 	}
 }
 
-func (s *RPCStream) init() {
+func (s *RPCStream) initSubscriptions() {
 	if s.headerStream != nil {
 		// already initialized
 		return
 	}
 
 	s.headerStream = NewStream[RPCHeader](headerStreamSegmentSize, headerStreamCapacity)
-	s.pendingTxStream = NewStream[common.Hash](txStreamSegmentSize, txStreamCapacity)
 	s.logStream = NewStream[*ethtypes.Log](logStreamSegmentSize, logStreamCapacity)
 
 	ctx := context.Background()
@@ -121,17 +124,16 @@ func (s *RPCStream) Close() error {
 }
 
 func (s *RPCStream) HeaderStream() *Stream[RPCHeader] {
-	s.init()
+	s.initSubscriptions()
 	return s.headerStream
 }
 
 func (s *RPCStream) PendingTxStream() *Stream[common.Hash] {
-	s.init()
 	return s.pendingTxStream
 }
 
 func (s *RPCStream) LogStream() *Stream[*ethtypes.Log] {
-	s.init()
+	s.initSubscriptions()
 	return s.logStream
 }
 

--- a/server/json_rpc.go
+++ b/server/json_rpc.go
@@ -38,10 +38,7 @@ import (
 	ethermint "github.com/evmos/ethermint/types"
 )
 
-const (
-	ServerStartTime = 5 * time.Second
-	MaxRetry        = 6
-)
+const ServerStartTime = 5 * time.Second
 
 type AppWithPendingTxStream interface {
 	RegisterPendingTxListener(listener ante.PendingTxListener)
@@ -64,20 +61,8 @@ func StartJSONRPC(
 		return nil, fmt.Errorf("client %T does not implement EventsClient", clientCtx.Client)
 	}
 
-	var rpcStream *stream.RPCStream
-	var err error
 	queryClient := rpctypes.NewQueryClient(clientCtx)
-	for i := 0; i < MaxRetry; i++ {
-		rpcStream, err = stream.NewRPCStreams(evtClient, logger, clientCtx.TxConfig.TxDecoder(), queryClient.ValidatorAccount)
-		if err == nil {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to create rpc streams after %d attempts: %w", MaxRetry, err)
-	}
+	rpcStream := stream.NewRPCStreams(evtClient, logger, clientCtx.TxConfig.TxDecoder(), queryClient.ValidatorAccount)
 
 	app.RegisterPendingTxListener(rpcStream.ListenPendingTx)
 


### PR DESCRIPTION
Solution:
- init the underlying subscriptions lazily.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
