### PR TITLE
test: add unit test TestGasCapOverInt64MaxNonceInQuery

### DIFF
--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -1307,6 +1307,43 @@ func (suite *GRPCServerTestSuiteSuite) TestNonceInQuery() {
 	suite.Require().NoError(err)
 }
 
+func (suite *GRPCServerTestSuiteSuite) TestGasCapOverInt64MaxNonceInQuery() {
+	suite.SetupTest()
+	address := tests.GenerateAddress()
+	suite.Require().Equal(uint64(0), suite.App.EvmKeeper.GetNonce(suite.Ctx, address))
+	supply := sdkmath.NewIntWithDecimal(1000, 18).BigInt()
+
+	// accupy nonce 0
+	_ = suite.deployTestContract(address)
+
+	gasCap := uint64(math.MaxInt64) + 1234567
+
+	// do an EthCall/EstimateGas with nonce 0
+	ctorArgs, err := types.ERC20Contract.ABI.Pack("", address, supply)
+	suite.Require().NoError(err)
+
+	data := append(types.ERC20Contract.Bin, ctorArgs...)
+	args, err := json.Marshal(&types.TransactionArgs{
+		From: &address,
+		Data: (*hexutil.Bytes)(&data),
+	})
+	suite.Require().NoError(err)
+	proposerAddress := suite.Ctx.BlockHeader().ProposerAddress
+	_, err = suite.EvmQueryClient.EstimateGas(suite.Ctx, &types.EthCallRequest{
+		Args:            args,
+		GasCap:          gasCap,
+		ProposerAddress: proposerAddress,
+	})
+	suite.Require().NoError(err)
+
+	_, err = suite.EvmQueryClient.EthCall(suite.Ctx, &types.EthCallRequest{
+		Args:            args,
+		GasCap:          gasCap,
+		ProposerAddress: proposerAddress,
+	})
+	suite.Require().NoError(err)
+}
+
 func (suite *GRPCServerTestSuiteSuite) TestQueryBaseFee() {
 	var (
 		aux    sdkmath.Int


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

This test is taken from https://github.com/crypto-org-chain/ethermint/blob/e59b7ae44eb57705092c3c6a5968a8c4ef0c6325/x/evm/simulation/operations.go#L206-L213
and https://github.com/crypto-org-chain/ethermint/blob/e59b7ae44eb57705092c3c6a5968a8c4ef0c6325/x/evm/keeper/state_transition.go#L410-L416

when the msg.GasLimit exceeds math.Int64Max, current implement correctly handles the logic. 
Therefore, we should ensure the same correct behavior when updating this implementation.


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
