### PR TITLE
fix: setting evm hooks prevent the stateDB from committing for failed tx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - name: "Checkout Repository"
         uses: actions/checkout@v5

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - name: release dry run
         run: make release-dry-run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       # Required: setup-go, for all versions v3.0.0+ of golangci-lint
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - uses: actions/checkout@v5
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - uses: actions/checkout@v5
       - uses: technote-space/get-diff-action@v6.1.2
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - uses: actions/checkout@v5
       - uses: technote-space/get-diff-action@v6.1.2
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - uses: actions/checkout@v5
       - uses: technote-space/get-diff-action@v6.1.2
@@ -154,7 +154,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - uses: actions/checkout@v5
       - uses: technote-space/get-diff-action@v6.1.2
@@ -174,7 +174,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - uses: actions/checkout@v5
       - uses: technote-space/get-diff-action@v6.1.2
@@ -194,7 +194,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - uses: actions/checkout@v5
       - uses: technote-space/get-diff-action@v6.1.2
@@ -214,7 +214,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.23
           check-latest: true
       - uses: actions/checkout@v5
       - uses: technote-space/get-diff-action@v6.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 * (evm) [#725](https://github.com/crypto-org-chain/ethermint/pull/725) feat(RPC): add authorizationList from eth_getTransactionByHash response for EIP-7702 transactions
+* (evm) [#735](https://github.com/crypto-org-chain/ethermint/pull/735) feat: allow PostTxProcessing to run on failures and persist data
 
 ## [v0.22.0] - 2025-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 * (evm) [#725](https://github.com/crypto-org-chain/ethermint/pull/725) feat(RPC): add authorizationList from eth_getTransactionByHash response for EIP-7702 transactions
-* (evm) [#735](https://github.com/crypto-org-chain/ethermint/pull/735) feat: allow PostTxProcessing to run on failures and persist data
+* (evm) [#735](https://github.com/crypto-org-chain/ethermint/pull/735) fix: setting evm hooks prevent the stateDB from committing for failed tx
 
 ## [v0.22.0] - 2025-08-12
 

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -442,7 +442,7 @@ func (suite *HandlerTestSuite) TestERC20TransferReverted() {
 			"failure hooks",
 			1000000, // enough gas limit, but hooks fails.
 			&FailureHook{},
-			"failed to execute post processing",
+			"failed to execute post transaction processing: mock error",
 		},
 	}
 
@@ -484,8 +484,8 @@ func (suite *HandlerTestSuite) TestERC20TransferReverted() {
 
 			rules := params.Rules{
 				IsHomestead: true,
-				IsIstanbul: true,
-				IsShanghai: true,
+				IsIstanbul:  true,
+				IsShanghai:  true,
 			}
 			fees, err := keeper.VerifyFee(tx, "aphoton", baseFee, rules, suite.Ctx.IsCheckTx())
 			suite.Require().NoError(err)

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -442,7 +442,7 @@ func (suite *HandlerTestSuite) TestERC20TransferReverted() {
 			"failure hooks",
 			1000000, // enough gas limit, but hooks fails.
 			&FailureHook{},
-			"failed to execute post transaction processing: mock error",
+			"failed to execute post processing",
 		},
 	}
 

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -168,7 +168,7 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 	msg := msgEth.AsMessage(cfg.BaseFee)
 
 	// Create a cache context to revert state when tx hooks fails,
-	// the cache context is only committed when both tx and hooks executed successfully.
+	// the cache context will only be discarded only if tx hooks fails.
 	// Didn't use `Snapshot` because the context stack has exponential complexity on certain operations,
 	// thus restricted to be used only inside `ApplyMessage`.
 	tmpCtx, commitFn := ctx.CacheContext()
@@ -211,10 +211,6 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 
 	if res.Failed() {
 		receipt.Status = ethtypes.ReceiptStatusFailed
-
-		// If the tx failed we discard the old context and create a new one, so
-		// PostTxProcessing can persist data even if the tx fails.
-		tmpCtx, commitFn = ctx.CacheContext()
 	} else {
 		receipt.Status = ethtypes.ReceiptStatusSuccessful
 	}

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -166,20 +166,19 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 	}
 
 	msg := msgEth.AsMessage(cfg.BaseFee)
-	// snapshot to contain the tx processing and post processing in same scope
-	var commit func()
-	tmpCtx := ctx
-	if k.hooks != nil {
-		// Create a cache context to revert state when tx hooks fails,
-		// the cache context is only committed when both tx and hooks executed successfully.
-		// Didn't use `Snapshot` because the context stack has exponential complexity on certain operations,
-		// thus restricted to be used only inside `ApplyMessage`.
-		tmpCtx, commit = ctx.CacheContext()
-	}
+
+	// Create a cache context to revert state when tx hooks fails,
+	// the cache context is only committed when both tx and hooks executed successfully.
+	// Didn't use `Snapshot` because the context stack has exponential complexity on certain operations,
+	// thus restricted to be used only inside `ApplyMessage`.
+	tmpCtx, commitFn := ctx.CacheContext()
 
 	// pass true to commit the StateDB
 	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, cfg, true)
 	if err != nil {
+		// when a transaction contains multiple msg, as long as one of the msg fails
+		// all gas will be deducted. so is not msg.Gas()
+		k.ResetGasMeterAndConsumeGas(tmpCtx, tmpCtx.GasMeter().Limit())
 		return nil, errorsmod.Wrap(err, "failed to apply ethereum core message")
 	}
 
@@ -206,33 +205,67 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 		Type:            ethTx.Type(),
 		PostState:       nil, // TODO: intermediate state root
 		Logs:            logs,
-		TxHash:          cfg.TxConfig.TxHash,
 		ContractAddress: contractAddr,
 		GasUsed:         res.GasUsed,
-		BlockHash:       cfg.TxConfig.BlockHash,
-		BlockNumber:     cfg.BlockNumber,
 	}
 
-	if !res.Failed() {
-		receipt.Status = ethtypes.ReceiptStatusSuccessful
-		// Only call hooks if tx executed successfully.
-		if err = k.PostTxProcessing(tmpCtx, msg, receipt); err != nil {
-			// If hooks return error, revert the whole tx.
-			res.VmError = types.ErrPostTxProcessing.Error()
-			k.Logger(ctx).Error("tx post processing failed", "error", err)
+	if res.Failed() {
+		receipt.Status = ethtypes.ReceiptStatusFailed
 
-			// If the tx failed in post processing hooks, we should clear the logs
+		// If the tx failed we discard the old context and create a new one, so
+		// PostTxProcessing can persist data even if the tx fails.
+		tmpCtx, commitFn = ctx.CacheContext()
+	} else {
+		receipt.Status = ethtypes.ReceiptStatusSuccessful
+	}
+
+	eventsLen := len(tmpCtx.EventManager().Events())
+
+	// Only call PostTxProcessing if there are hooks set, to avoid calling commitFn unnecessarily
+	if k.hooks == nil {
+		// If there are no hooks, we can commit the state immediately if the tx is successful
+		if commitFn != nil && !res.Failed() {
+			commitFn()
+		}
+	} else {
+		// Note: PostTxProcessing hooks currently do not charge for gas
+		// and function similar to EndBlockers in abci, but for EVM transactions.
+		// It will persist data even if the tx fails.
+		err = k.PostTxProcessing(tmpCtx, msg, receipt)
+		if err != nil {
+			// If hooks returns an error, revert the whole tx.
+			res.VmError = errorsmod.Wrap(err, "failed to execute post transaction processing").Error()
+			k.Logger(ctx).Error("tx post processing failed", "error", err)
+			// If the tx failed in post processing hooks, we should clear all log-related data
+			// to match EVM behavior where transaction reverts clear all effects including logs
 			res.Logs = nil
-		} else if commit != nil {
-			// PostTxProcessing is successful, commit the tmpCtx
-			commit()
+			receipt.Logs = nil
+			receipt.Bloom = ethtypes.Bloom{} // Clear bloom filter
+		} else {
+			if commitFn != nil {
+				commitFn()
+			}
+
 			// Since the post-processing can alter the log, we need to update the result
-			res.Logs = types.NewLogsFromEth(receipt.Logs)
+			if res.Failed() {
+				res.Logs = nil
+				receipt.Logs = nil
+				receipt.Bloom = ethtypes.Bloom{}
+			} else {
+				res.Logs = types.NewLogsFromEth(receipt.Logs)
+			}
+
+			events := tmpCtx.EventManager().Events()
+			if len(events) > eventsLen {
+				ctx.EventManager().EmitEvents(events[eventsLen:])
+			}
 		}
 	}
 
-	// Get the tracer and add OnGasChange hook for gas refund
-	leftoverGas := msg.GasLimit - res.GasUsed
+	leftoverGas := uint64(0)
+	if msg.GasLimit > res.GasUsed {
+		leftoverGas = msg.GasLimit - res.GasUsed
+	}
 
 	// refund gas in order to match the Ethereum gas consumption instead of the default SDK one.
 	if err = k.RefundGas(ctx, msg, leftoverGas, cfg.Params.EvmDenom); err != nil {

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -171,7 +171,11 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 	// the cache context will only be discarded only if tx hooks fails.
 	// Didn't use `Snapshot` because the context stack has exponential complexity on certain operations,
 	// thus restricted to be used only inside `ApplyMessage`.
-	tmpCtx, commitFn := ctx.CacheContext()
+	var commit func()
+	tmpCtx := ctx
+	if k.hooks != nil {
+		tmpCtx, commit = ctx.CacheContext()
+	}
 
 	// pass true to commit the StateDB
 	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, cfg, true)
@@ -215,47 +219,19 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 		receipt.Status = ethtypes.ReceiptStatusSuccessful
 	}
 
-	eventsLen := len(tmpCtx.EventManager().Events())
+	postTxProcessingError := k.PostTxProcessing(tmpCtx, msg, receipt)
+	if postTxProcessingError != nil {
+		// If hooks return error, revert the whole tx.
+		res.VmError = types.ErrPostTxProcessing.Error()
+		k.Logger(ctx).Error("tx post processing failed", "error", err)
 
-	// Only call PostTxProcessing if there are hooks set, to avoid calling commitFn unnecessarily
-	if k.hooks == nil {
-		// If there are no hooks, we can commit the state immediately if the tx is successful
-		if commitFn != nil && !res.Failed() {
-			commitFn()
-		}
-	} else {
-		// Note: PostTxProcessing hooks currently do not charge for gas
-		// and function similar to EndBlockers in abci, but for EVM transactions.
-		// It will persist data even if the tx fails.
-		err = k.PostTxProcessing(tmpCtx, msg, receipt)
-		if err != nil {
-			// If hooks returns an error, revert the whole tx.
-			res.VmError = errorsmod.Wrap(err, "failed to execute post transaction processing").Error()
-			k.Logger(ctx).Error("tx post processing failed", "error", err)
-			// If the tx failed in post processing hooks, we should clear all log-related data
-			// to match EVM behavior where transaction reverts clear all effects including logs
-			res.Logs = nil
-			receipt.Logs = nil
-			receipt.Bloom = ethtypes.Bloom{} // Clear bloom filter
-		} else {
-			if commitFn != nil {
-				commitFn()
-			}
-
-			// Since the post-processing can alter the log, we need to update the result
-			if res.Failed() {
-				res.Logs = nil
-				receipt.Logs = nil
-				receipt.Bloom = ethtypes.Bloom{}
-			} else {
-				res.Logs = types.NewLogsFromEth(receipt.Logs)
-			}
-
-			events := tmpCtx.EventManager().Events()
-			if len(events) > eventsLen {
-				ctx.EventManager().EmitEvents(events[eventsLen:])
-			}
-		}
+		// If the tx failed in post processing hooks, we should clear the logs
+		res.Logs = nil
+	} else if commit != nil {
+		// PostTxProcessing is successful, commit the tmpCtx, whether the tx failed or not.
+		commit()
+		// Since the post-processing can alter the log, we need to update the result
+		res.Logs = types.NewLogsFromEth(receipt.Logs)
 	}
 
 	leftoverGas := uint64(0)

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -166,23 +166,20 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 	}
 
 	msg := msgEth.AsMessage(cfg.BaseFee)
-
-	// Create a cache context to revert state when tx hooks fails,
-	// the cache context will only be discarded only if tx hooks fails.
-	// Didn't use `Snapshot` because the context stack has exponential complexity on certain operations,
-	// thus restricted to be used only inside `ApplyMessage`.
+	// snapshot to contain the tx processing and post processing in same scope
 	var commit func()
 	tmpCtx := ctx
 	if k.hooks != nil {
+		// Create a cache context to revert state when tx hooks fails,
+		// the cache context will only be discarded only if tx hooks fails.
+		// Didn't use `Snapshot` because the context stack has exponential complexity on certain operations,
+		// thus restricted to be used only inside `ApplyMessage`.
 		tmpCtx, commit = ctx.CacheContext()
 	}
 
 	// pass true to commit the StateDB
 	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, cfg, true)
 	if err != nil {
-		// when a transaction contains multiple msg, as long as one of the msg fails
-		// all gas will be deducted. so is not msg.Gas()
-		k.ResetGasMeterAndConsumeGas(tmpCtx, tmpCtx.GasMeter().Limit())
 		return nil, errorsmod.Wrap(err, "failed to apply ethereum core message")
 	}
 
@@ -209,17 +206,21 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 		Type:            ethTx.Type(),
 		PostState:       nil, // TODO: intermediate state root
 		Logs:            logs,
+		TxHash:          cfg.TxConfig.TxHash,
 		ContractAddress: contractAddr,
 		GasUsed:         res.GasUsed,
+		BlockHash:       cfg.TxConfig.BlockHash,
+		BlockNumber:     cfg.BlockNumber,
 	}
 
+	var postTxProcessingError error
 	if res.Failed() {
 		receipt.Status = ethtypes.ReceiptStatusFailed
 	} else {
 		receipt.Status = ethtypes.ReceiptStatusSuccessful
+		postTxProcessingError = k.PostTxProcessing(tmpCtx, msg, receipt)
 	}
 
-	postTxProcessingError := k.PostTxProcessing(tmpCtx, msg, receipt)
 	if postTxProcessingError != nil {
 		// If hooks return error, revert the whole tx.
 		res.VmError = types.ErrPostTxProcessing.Error()
@@ -228,7 +229,7 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 		// If the tx failed in post processing hooks, we should clear the logs
 		res.Logs = nil
 	} else if commit != nil {
-		// PostTxProcessing is successful, commit the tmpCtx, whether the tx failed or not.
+		// as long as the post processing is successful, commit the tmpCtx whether the tx failed or not.
 		commit()
 		// Since the post-processing can alter the log, we need to update the result
 		res.Logs = types.NewLogsFromEth(receipt.Logs)

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -812,7 +812,7 @@ func (suite *StateTransitionTestSuite) TestApplyTransactionWithTxPostProcessing(
 		after func(suite *StateTransitionTestSuite)
 	}{
 		{
-			"pass - evm tx succeeds, post processing is called, the balance is changed",
+			"evm tx succeeds, post processing success, the state is committed",
 			func(suite *StateTransitionTestSuite) {
 				suite.App.EvmKeeper.SetHooks(
 					keeper.NewMultiEvmHooks(
@@ -866,7 +866,7 @@ func (suite *StateTransitionTestSuite) TestApplyTransactionWithTxPostProcessing(
 			},
 		},
 		{
-			"pass - evm tx succeeds, post processing is called but fails, the balance is unchanged",
+			"evm tx succeeds, post processing is called but fails, the state will not be committed",
 			func(suite *StateTransitionTestSuite) {
 				suite.App.EvmKeeper.SetHooks(
 					keeper.NewMultiEvmHooks(
@@ -919,79 +919,17 @@ func (suite *StateTransitionTestSuite) TestApplyTransactionWithTxPostProcessing(
 			func(suite *StateTransitionTestSuite) {
 			},
 		},
-		{
-			"evm tx fails, post processing is called and persisted, the balance is not changed",
-			func(suite *StateTransitionTestSuite) {
-				suite.App.EvmKeeper.SetHooks(
-					keeper.NewMultiEvmHooks(
-						&testHooks{
-							postProcessing: func(ctx sdk.Context, msg *core.Message, receipt *ethtypes.Receipt) error {
-								return suite.App.MintKeeper.MintCoins(
-									ctx, sdk.NewCoins(sdk.NewCoin("arandomcoin", sdkmath.NewInt(100))),
-								)
-							},
-						},
-					),
-				)
-			},
-			func(suite *StateTransitionTestSuite) {
-				sender := suite.Address
-				recipient := tests.GenerateAddress()
-
-				suite.App.EvmKeeper.SetBalance(suite.Ctx, sender, *uint256.NewInt(10000), evmtypes.DefaultEVMDenom)
-
-				senderBefore := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(sender.Bytes()), evmtypes.DefaultEVMDenom)
-				recipientBefore := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(recipient.Bytes()), evmtypes.DefaultEVMDenom)
-				transferAmt := uint256.NewInt(0).Add(&senderBefore, uint256.NewInt(100)).ToBig() // transfer more than the balance
-
-				nonce := suite.App.EvmKeeper.GetNonce(suite.Ctx, suite.Address)
-				chainID := suite.App.EvmKeeper.ChainID()
-
-				tx := types.NewTx(
-					chainID,
-					nonce,
-					&recipient,
-					transferAmt,
-					params.TxGas,
-					big.NewInt(1000000000), // gasPrice
-					nil, nil,               // gasFeeCap, gasTipCap
-					nil, // data
-					nil, // accessList
-				)
-
-				tx.From = suite.Address.Bytes()
-				err := tx.Sign(ethtypes.LatestSignerForChainID(chainID), suite.Signer)
-				suite.Require().NoError(err)
-
-				res, err := suite.App.EvmKeeper.ApplyTransaction(suite.Ctx, tx)
-				suite.Require().NoError(err)
-				suite.Require().True(res.Failed())
-
-				senderAfter := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(sender.Bytes()), evmtypes.DefaultEVMDenom)
-				recipientAfter := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(recipient.Bytes()), evmtypes.DefaultEVMDenom)
-				suite.Require().Equal(senderBefore, senderAfter)
-				suite.Require().Equal(recipientBefore, recipientAfter)
-			},
-			func(suite *StateTransitionTestSuite) {
-				// check if the mint module has "arandomcoin" in its balance, it was minted in the post processing, proving that the post processing was called
-				// and that it can persist state even when the tx fails
-				balance := suite.App.BankKeeper.GetBalance(suite.Ctx, suite.App.AccountKeeper.GetModuleAddress(minttypes.ModuleName), "arandomcoin")
-				suite.Require().Equal(sdkmath.NewInt(100), balance.Amount)
-			},
-		},
 	}
 
 	for _, tc := range testCases {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.mintFeeCollector = true
 			suite.SetupTest()
 
 			tc.setup(suite)
 
-			// set bounded block gas limit
 			ctx := suite.Ctx.WithBlockGasMeter(storetypes.NewGasMeter(1e6))
 			err := suite.App.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(3e18))))
-			suite.Require().NoError(err)
-			err = suite.App.BankKeeper.SendCoinsFromModuleToModule(ctx, minttypes.ModuleName, authtypes.FeeCollectorName, sdk.NewCoins(sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(3e18))))
 			suite.Require().NoError(err)
 
 			tc.do(suite)

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -20,7 +21,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -796,6 +796,59 @@ func (suite *StateTransitionTestSuite) TestGetProposerAddress() {
 	}
 }
 
+type StateTransitionHooksTestSuite struct {
+	testutil.BaseTestSuiteWithAccount
+	chainID   *big.Int
+	ethSigner ethtypes.Signer
+	to        sdk.AccAddress
+}
+
+func TestStateTransitionHooksTestSuite(t *testing.T) {
+	suite.Run(t, new(StateTransitionHooksTestSuite))
+}
+
+func (suite *StateTransitionHooksTestSuite) SetupTest() {
+	coins := sdk.NewCoins(sdk.NewCoin(types.DefaultEVMDenom, sdkmath.NewInt(100000000000000)))
+
+	t := suite.T()
+	suite.SetupTestWithCb(t, func(app *evmd.EthermintApp, genesis evmd.GenesisState) evmd.GenesisState {
+		b32address := sdk.MustBech32ifyAddressBytes(sdk.GetConfig().GetBech32AccountAddrPrefix(), suite.ConsPubKey.Address().Bytes())
+		balances := []banktypes.Balance{
+			{
+				Address: b32address,
+				Coins:   coins,
+			},
+			{
+				Address: app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName).String(),
+				Coins:   coins,
+			},
+		}
+		var bankGenesis banktypes.GenesisState
+		app.AppCodec().MustUnmarshalJSON(genesis[banktypes.ModuleName], &bankGenesis)
+		// Update balances and total supply
+		bankGenesis.Balances = append(bankGenesis.Balances, balances...)
+		bankGenesis.Supply = bankGenesis.Supply.Add(coins...).Add(coins...)
+		genesis[banktypes.ModuleName] = app.AppCodec().MustMarshalJSON(&bankGenesis)
+		acc := &ethermint.EthAccount{
+			BaseAccount: authtypes.NewBaseAccount(sdk.AccAddress(suite.Address.Bytes()), nil, 0, 0),
+			CodeHash:    common.BytesToHash(crypto.Keccak256(nil)).String(),
+		}
+		accs, err := authtypes.PackAccounts(authtypes.GenesisAccounts{acc})
+		require.NoError(t, err)
+		var authGenesis authtypes.GenesisState
+		app.AppCodec().MustUnmarshalJSON(genesis[authtypes.ModuleName], &authGenesis)
+		authGenesis.Accounts = append(authGenesis.Accounts, accs[0])
+		genesis[authtypes.ModuleName] = app.AppCodec().MustMarshalJSON(&authGenesis)
+		return genesis
+	})
+
+	// add some virtual balance to the fee collector for refunding
+	suite.MintFeeCollectorVirtual(coins)
+
+	suite.ethSigner = ethtypes.LatestSignerForChainID(suite.App.EvmKeeper.ChainID())
+	suite.chainID = suite.App.EvmKeeper.ChainID()
+}
+
 type testHooks struct {
 	postProcessing func(ctx sdk.Context, msg *core.Message, receipt *ethtypes.Receipt) error
 }
@@ -804,16 +857,16 @@ func (h *testHooks) PostTxProcessing(ctx sdk.Context, msg *core.Message, receipt
 	return h.postProcessing(ctx, msg, receipt)
 }
 
-func (suite *StateTransitionTestSuite) TestApplyTransactionWithTxPostProcessing() {
+func (suite *StateTransitionHooksTestSuite) TestApplyTransactionWithTxPostProcessing() {
 	testCases := []struct {
 		name  string
-		setup func(suite *StateTransitionTestSuite)
-		do    func(suite *StateTransitionTestSuite)
-		after func(suite *StateTransitionTestSuite)
+		setup func(suite *StateTransitionHooksTestSuite)
+		do    func(suite *StateTransitionHooksTestSuite)
+		after func(suite *StateTransitionHooksTestSuite)
 	}{
 		{
-			"evm tx succeeds, post processing success, the state is committed",
-			func(suite *StateTransitionTestSuite) {
+			"evm tx success, hooks success, state is committed",
+			func(suite *StateTransitionHooksTestSuite) {
 				suite.App.EvmKeeper.SetHooks(
 					keeper.NewMultiEvmHooks(
 						&testHooks{
@@ -824,7 +877,7 @@ func (suite *StateTransitionTestSuite) TestApplyTransactionWithTxPostProcessing(
 					),
 				)
 			},
-			func(suite *StateTransitionTestSuite) {
+			func(suite *StateTransitionHooksTestSuite) {
 				sender := suite.Address
 				recipient := tests.GenerateAddress()
 
@@ -862,12 +915,12 @@ func (suite *StateTransitionTestSuite) TestApplyTransactionWithTxPostProcessing(
 				suite.Require().Equal(*uint256.NewInt(0).Sub(&senderBefore, uint256.MustFromBig(transferAmt)), senderAfter)
 				suite.Require().Equal(*uint256.NewInt(0).Add(&recipientBefore, uint256.MustFromBig(transferAmt)), recipientAfter)
 			},
-			func(suite *StateTransitionTestSuite) {
+			func(suite *StateTransitionHooksTestSuite) {
 			},
 		},
 		{
-			"evm tx succeeds, post processing is called but fails, the state will not be committed",
-			func(suite *StateTransitionTestSuite) {
+			"evm tx success, hooks failed, the state will be discarded",
+			func(suite *StateTransitionHooksTestSuite) {
 				suite.App.EvmKeeper.SetHooks(
 					keeper.NewMultiEvmHooks(
 						&testHooks{
@@ -878,7 +931,7 @@ func (suite *StateTransitionTestSuite) TestApplyTransactionWithTxPostProcessing(
 					),
 				)
 			},
-			func(suite *StateTransitionTestSuite) {
+			func(suite *StateTransitionHooksTestSuite) {
 				sender := suite.Address
 				recipient := tests.GenerateAddress()
 
@@ -916,21 +969,96 @@ func (suite *StateTransitionTestSuite) TestApplyTransactionWithTxPostProcessing(
 				suite.Require().Equal(senderBefore, senderAfter)
 				suite.Require().Equal(recipientBefore, recipientAfter)
 			},
-			func(suite *StateTransitionTestSuite) {
+			func(suite *StateTransitionHooksTestSuite) {
+			},
+		},
+		{
+			"evm tx fails, post processing is never called, the state will be committed",
+			func(suite *StateTransitionHooksTestSuite) {
+				suite.App.EvmKeeper.SetHooks(
+					keeper.NewMultiEvmHooks(
+						&testHooks{
+							postProcessing: func(ctx sdk.Context, msg *core.Message, receipt *ethtypes.Receipt) error {
+								return nil
+							},
+						},
+					),
+				)
+			},
+			func(suite *StateTransitionHooksTestSuite) {
+				// Deploy Couter Contract without receive/fallback
+				bytecode := common.FromHex("6080604052348015600e575f5ffd5b5060f58061001b5f395ff3fe6080604052348015600e575f5ffd5b5060043610603a575f3560e01c806306661abd14603e578063d732d955146057578063e8927fbc14605f575b5f5ffd5b60455f5481565b60405190815260200160405180910390f35b605d6065565b005b605d6078565b5f805490806071836098565b9190505550565b5f8054908060718360aa565b634e487b7160e01b5f52601160045260245ffd5b5f8160a35760a36084565b505f190190565b5f6001820160b85760b86084565b506001019056fea26469706673582212207f3bf5ba2685b5c86c79dfeeae5daba97b0f22f464e7e4b41775a3864db68f6a64736f6c634300081c0033")
+				gasLimit := uint64(1000000)
+				gasPrice := big.NewInt(10000)
+
+				// Use the actual account nonce for contract deployment
+				deployNonce := suite.App.EvmKeeper.GetNonce(suite.Ctx, suite.Address)
+				tx := types.NewTx(suite.chainID, deployNonce, nil, big.NewInt(0), gasLimit, gasPrice, nil, nil, bytecode, nil)
+				tx.From = suite.Address.Bytes()
+				err := tx.Sign(ethtypes.LatestSignerForChainID(suite.chainID), suite.Signer)
+				suite.Require().NoError(err)
+
+				res, err := suite.App.EvmKeeper.EthereumTx(suite.Ctx, tx)
+				suite.Require().NoError(err)
+				suite.Require().False(res.Failed())
+
+				// Get contract address from transaction
+				contractAddr := crypto.CreateAddress(suite.Address, deployNonce)
+
+				// delegate the account to the contract
+				// Create and sign a SetCodeAuthorization for EIP-7702
+				// Use the current nonce after contract deployment
+				currentNonce := suite.App.EvmKeeper.GetNonce(suite.Ctx, suite.Address)
+				unsignedAuth := ethtypes.SetCodeAuthorization{
+					ChainID: *uint256.MustFromBig(suite.chainID),
+					Address: contractAddr,
+					Nonce:   currentNonce,
+				}
+				privKey, err := suite.PrivKey.ToECDSA()
+				suite.Require().NoError(err)
+				auth, err := ethtypes.SignSetCode(privKey, unsignedAuth)
+				suite.Require().NoError(err)
+
+				// Create EIP-7702 SetCodeTx
+				setCodeTx := &ethtypes.SetCodeTx{
+					ChainID:    uint256.MustFromBig(suite.chainID),
+					Nonce:      2,
+					GasTipCap:  uint256.NewInt(1000000000),
+					GasFeeCap:  uint256.NewInt(2000000000),
+					Gas:        50000,
+					To:         suite.Address,
+					Value:      uint256.NewInt(0),
+					Data:       nil,
+					AccessList: ethtypes.AccessList{},
+					AuthList:   []ethtypes.SetCodeAuthorization{auth},
+				}
+
+				tx = types.NewTxWithData(setCodeTx)
+				tx.From = suite.Address.Bytes()
+				err = tx.Sign(ethtypes.LatestSignerForChainID(suite.chainID), suite.Signer)
+				suite.Require().NoError(err)
+
+				res2, err := suite.App.EvmKeeper.ApplyTransaction(suite.Ctx, tx)
+				suite.Require().NoError(err)
+				suite.Require().True(res2.Failed())
+
+				account := suite.App.EvmKeeper.GetAccount(suite.Ctx, suite.Address)
+				suite.Require().NotNil(account)
+				code := suite.App.EvmKeeper.GetCode(suite.Ctx, common.Hash(account.CodeHash))
+				// 0xef0100 + contractAddress
+				contractAddrBytes := contractAddr.Bytes()
+				suite.Require().Equal(code, common.FromHex("0xef0100"+hex.EncodeToString(contractAddrBytes)))
+			},
+			func(suite *StateTransitionHooksTestSuite) {
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
-			suite.mintFeeCollector = true
 			suite.SetupTest()
 
 			tc.setup(suite)
-
-			ctx := suite.Ctx.WithBlockGasMeter(storetypes.NewGasMeter(1e6))
-			err := suite.App.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(3e18))))
-			suite.Require().NoError(err)
 
 			tc.do(suite)
 

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -19,6 +20,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -35,6 +37,7 @@ import (
 	"github.com/evmos/ethermint/x/evm/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	feemarkettypes "github.com/evmos/ethermint/x/feemarket/types"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -789,6 +792,211 @@ func (suite *StateTransitionTestSuite) TestGetProposerAddress() {
 	for _, tc := range testCases {
 		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
 			suite.Require().Equal(tc.expAdr, keeper.GetProposerAddress(suite.Ctx, tc.adr))
+		})
+	}
+}
+
+type testHooks struct {
+	postProcessing func(ctx sdk.Context, msg *core.Message, receipt *ethtypes.Receipt) error
+}
+
+func (h *testHooks) PostTxProcessing(ctx sdk.Context, msg *core.Message, receipt *ethtypes.Receipt) error {
+	return h.postProcessing(ctx, msg, receipt)
+}
+
+func (suite *StateTransitionTestSuite) TestApplyTransactionWithTxPostProcessing() {
+	testCases := []struct {
+		name  string
+		setup func(suite *StateTransitionTestSuite)
+		do    func(suite *StateTransitionTestSuite)
+		after func(suite *StateTransitionTestSuite)
+	}{
+		{
+			"pass - evm tx succeeds, post processing is called, the balance is changed",
+			func(suite *StateTransitionTestSuite) {
+				suite.App.EvmKeeper.SetHooks(
+					keeper.NewMultiEvmHooks(
+						&testHooks{
+							postProcessing: func(ctx sdk.Context, msg *core.Message, receipt *ethtypes.Receipt) error {
+								return nil
+							},
+						},
+					),
+				)
+			},
+			func(suite *StateTransitionTestSuite) {
+				sender := suite.Address
+				recipient := tests.GenerateAddress()
+
+				suite.App.EvmKeeper.SetBalance(suite.Ctx, sender, *uint256.NewInt(10000), evmtypes.DefaultEVMDenom)
+
+				senderBefore := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(sender.Bytes()), evmtypes.DefaultEVMDenom)
+				recipientBefore := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(recipient.Bytes()), evmtypes.DefaultEVMDenom)
+				transferAmt := uint256.NewInt(100).ToBig()
+
+				nonce := suite.App.EvmKeeper.GetNonce(suite.Ctx, suite.Address)
+				chainID := suite.App.EvmKeeper.ChainID()
+
+				tx := types.NewTx(
+					chainID,
+					nonce,
+					&recipient,
+					transferAmt,
+					params.TxGas,
+					big.NewInt(1000000000), // gasPrice
+					nil, nil,               // gasFeeCap, gasTipCap
+					nil, // data
+					nil, // accessList
+				)
+
+				tx.From = suite.Address.Bytes()
+				err := tx.Sign(ethtypes.LatestSignerForChainID(chainID), suite.Signer)
+				suite.Require().NoError(err)
+
+				res, err := suite.App.EvmKeeper.ApplyTransaction(suite.Ctx, tx)
+				suite.Require().NoError(err)
+				suite.Require().False(res.Failed())
+
+				senderAfter := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(sender.Bytes()), evmtypes.DefaultEVMDenom)
+				recipientAfter := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(recipient.Bytes()), evmtypes.DefaultEVMDenom)
+				suite.Require().Equal(*uint256.NewInt(0).Sub(&senderBefore, uint256.MustFromBig(transferAmt)), senderAfter)
+				suite.Require().Equal(*uint256.NewInt(0).Add(&recipientBefore, uint256.MustFromBig(transferAmt)), recipientAfter)
+			},
+			func(suite *StateTransitionTestSuite) {
+			},
+		},
+		{
+			"pass - evm tx succeeds, post processing is called but fails, the balance is unchanged",
+			func(suite *StateTransitionTestSuite) {
+				suite.App.EvmKeeper.SetHooks(
+					keeper.NewMultiEvmHooks(
+						&testHooks{
+							postProcessing: func(ctx sdk.Context, msg *core.Message, receipt *ethtypes.Receipt) error {
+								return errors.New("post processing failed :(")
+							},
+						},
+					),
+				)
+			},
+			func(suite *StateTransitionTestSuite) {
+				sender := suite.Address
+				recipient := tests.GenerateAddress()
+
+				suite.App.EvmKeeper.SetBalance(suite.Ctx, sender, *uint256.NewInt(10000), evmtypes.DefaultEVMDenom)
+
+				senderBefore := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(sender.Bytes()), evmtypes.DefaultEVMDenom)
+				recipientBefore := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(recipient.Bytes()), evmtypes.DefaultEVMDenom)
+				transferAmt := uint256.NewInt(100).ToBig()
+
+				nonce := suite.App.EvmKeeper.GetNonce(suite.Ctx, suite.Address)
+				chainID := suite.App.EvmKeeper.ChainID()
+
+				tx := types.NewTx(
+					chainID,
+					nonce,
+					&recipient,
+					transferAmt,
+					params.TxGas,
+					big.NewInt(1000000000), // gasPrice
+					nil, nil,               // gasFeeCap, gasTipCap
+					nil, // data
+					nil, // accessList
+				)
+
+				tx.From = suite.Address.Bytes()
+				err := tx.Sign(ethtypes.LatestSignerForChainID(chainID), suite.Signer)
+				suite.Require().NoError(err)
+
+				res, err := suite.App.EvmKeeper.ApplyTransaction(suite.Ctx, tx)
+				suite.Require().NoError(err)
+				suite.Require().True(res.Failed())
+
+				senderAfter := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(sender.Bytes()), evmtypes.DefaultEVMDenom)
+				recipientAfter := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(recipient.Bytes()), evmtypes.DefaultEVMDenom)
+				suite.Require().Equal(senderBefore, senderAfter)
+				suite.Require().Equal(recipientBefore, recipientAfter)
+			},
+			func(suite *StateTransitionTestSuite) {
+			},
+		},
+		{
+			"evm tx fails, post processing is called and persisted, the balance is not changed",
+			func(suite *StateTransitionTestSuite) {
+				suite.App.EvmKeeper.SetHooks(
+					keeper.NewMultiEvmHooks(
+						&testHooks{
+							postProcessing: func(ctx sdk.Context, msg *core.Message, receipt *ethtypes.Receipt) error {
+								return suite.App.MintKeeper.MintCoins(
+									ctx, sdk.NewCoins(sdk.NewCoin("arandomcoin", sdkmath.NewInt(100))),
+								)
+							},
+						},
+					),
+				)
+			},
+			func(suite *StateTransitionTestSuite) {
+				sender := suite.Address
+				recipient := tests.GenerateAddress()
+
+				suite.App.EvmKeeper.SetBalance(suite.Ctx, sender, *uint256.NewInt(10000), evmtypes.DefaultEVMDenom)
+
+				senderBefore := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(sender.Bytes()), evmtypes.DefaultEVMDenom)
+				recipientBefore := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(recipient.Bytes()), evmtypes.DefaultEVMDenom)
+				transferAmt := uint256.NewInt(0).Add(&senderBefore, uint256.NewInt(100)).ToBig() // transfer more than the balance
+
+				nonce := suite.App.EvmKeeper.GetNonce(suite.Ctx, suite.Address)
+				chainID := suite.App.EvmKeeper.ChainID()
+
+				tx := types.NewTx(
+					chainID,
+					nonce,
+					&recipient,
+					transferAmt,
+					params.TxGas,
+					big.NewInt(1000000000), // gasPrice
+					nil, nil,               // gasFeeCap, gasTipCap
+					nil, // data
+					nil, // accessList
+				)
+
+				tx.From = suite.Address.Bytes()
+				err := tx.Sign(ethtypes.LatestSignerForChainID(chainID), suite.Signer)
+				suite.Require().NoError(err)
+
+				res, err := suite.App.EvmKeeper.ApplyTransaction(suite.Ctx, tx)
+				suite.Require().NoError(err)
+				suite.Require().True(res.Failed())
+
+				senderAfter := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(sender.Bytes()), evmtypes.DefaultEVMDenom)
+				recipientAfter := suite.App.EvmKeeper.GetBalance(suite.Ctx, sdk.AccAddress(recipient.Bytes()), evmtypes.DefaultEVMDenom)
+				suite.Require().Equal(senderBefore, senderAfter)
+				suite.Require().Equal(recipientBefore, recipientAfter)
+			},
+			func(suite *StateTransitionTestSuite) {
+				// check if the mint module has "arandomcoin" in its balance, it was minted in the post processing, proving that the post processing was called
+				// and that it can persist state even when the tx fails
+				balance := suite.App.BankKeeper.GetBalance(suite.Ctx, suite.App.AccountKeeper.GetModuleAddress(minttypes.ModuleName), "arandomcoin")
+				suite.Require().Equal(sdkmath.NewInt(100), balance.Amount)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.SetupTest()
+
+			tc.setup(suite)
+
+			// set bounded block gas limit
+			ctx := suite.Ctx.WithBlockGasMeter(storetypes.NewGasMeter(1e6))
+			err := suite.App.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(3e18))))
+			suite.Require().NoError(err)
+			err = suite.App.BankKeeper.SendCoinsFromModuleToModule(ctx, minttypes.ModuleName, authtypes.FeeCollectorName, sdk.NewCoins(sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(3e18))))
+			suite.Require().NoError(err)
+
+			tc.do(suite)
+
+			tc.after(suite)
 		})
 	}
 }


### PR DESCRIPTION
EIP-7702 transactions are processed before the EVM call, and their updates are meant to be applied as part of the transaction, regardless of whether the call succeeds or fails. 

Previously, if EVM hooks were set and the transaction failed, any state changes  would be lost—for example, the account code would not be set when sending 7702 tx to a contract without fallback func. 

This PR ensures that whether the hook being set or not these top-level state changes are committed

We will only discard state when hooks set and hooks run failed