### PR TITLE
fix: staking optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+* (deps) [#776](https://github.com/crypto-org-chain/ethermint/pull/776) fix: Optimize staking endblocker with an in-memory KV store and standardize gas consumption for staking related messages.
 * (evm) [#725](https://github.com/crypto-org-chain/ethermint/pull/725) feat(RPC): add authorizationList from eth_getTransactionByHash response for EIP-7702 transactions
 * (evm) [#740](https://github.com/crypto-org-chain/ethermint/pull/740) fix: missing tx context during vm initialisation
 * (evm) [#742](https://github.com/crypto-org-chain/ethermint/pull/742) fix: prevent nil pointer dereference in tracer hooks

--- a/ante/cosmos/fixed_gas.go
+++ b/ante/cosmos/fixed_gas.go
@@ -1,0 +1,66 @@
+package cosmos
+
+import (
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// FixedGasConsumedDecorator consumes a fixed amount of gas for whitelisted messages
+// and then replaces the gas meter with a fixed gas meter to prevent additional gas consumption
+type FixedGasConsumedDecorator struct{}
+
+var WhitelistedMessages = map[string]uint64{
+	sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}):      200000,
+	sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}): 232000,
+}
+
+// NewFixedGasConsumedDecorator creates a new FixedGasConsumedDecorator
+func NewFixedGasConsumedDecorator() FixedGasConsumedDecorator {
+	return FixedGasConsumedDecorator{}
+}
+
+type fixedGasMeter struct {
+	consumed storetypes.Gas
+}
+
+// NewFixedGasMeter returns a new gas meter with a fixed amount of consumed gas.
+func NewFixedGasMeter(consumed storetypes.Gas) storetypes.GasMeter {
+	return &fixedGasMeter{
+		consumed: consumed,
+	}
+}
+
+var _ storetypes.GasMeter = &fixedGasMeter{}
+
+func (fgm *fixedGasMeter) GasConsumed() storetypes.Gas        { return fgm.consumed }
+func (fgm *fixedGasMeter) GasConsumedToLimit() storetypes.Gas { return fgm.consumed }
+func (fgm *fixedGasMeter) GasRemaining() storetypes.Gas       { return 0 }
+func (fgm *fixedGasMeter) Limit() storetypes.Gas              { return fgm.consumed }
+func (fgm *fixedGasMeter) ConsumeGas(storetypes.Gas, string)  {}
+func (fgm *fixedGasMeter) RefundGas(storetypes.Gas, string)   {}
+func (fgm *fixedGasMeter) IsPastLimit() bool                  { return false }
+func (fgm *fixedGasMeter) IsOutOfGas() bool                   { return false }
+func (fgm *fixedGasMeter) String() string                     { return "fixedGasMeter" }
+
+func (fgcd FixedGasConsumedDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	msgs := tx.GetMsgs()
+	totalFixedGas := uint64(0)
+	whitelistedMsgsPresent := false
+
+	for _, msg := range msgs {
+		msgTypeURL := sdk.MsgTypeURL(msg)
+		if fixedGas, found := WhitelistedMessages[msgTypeURL]; found {
+			whitelistedMsgsPresent = true
+			totalFixedGas += fixedGas
+		}
+	}
+
+	if whitelistedMsgsPresent {
+		ctx.GasMeter().ConsumeGas(totalFixedGas, "fixed gas for whitelisted messages")
+		consumedGas := ctx.GasMeter().GasConsumed()
+		ctx = ctx.WithGasMeter(NewFixedGasMeter(consumedGas))
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/evmd/ante/ante_test.go
+++ b/evmd/ante/ante_test.go
@@ -356,7 +356,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 			"success - DeliverTx EIP712 signed Cosmos Tx with DelegateMsg",
 			func() sdk.Tx {
 				from := acc.GetAddress()
-				gas := uint64(200000)
+				gas := uint64(300000)
 				coinAmount := sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(100*int64(gas)))
 				amount := sdk.NewCoins(coinAmount)
 				txBuilder := suite.CreateTestEIP712TxBuilderMsgDelegate(from, privKey, "ethermint_9000-1", gas, amount)
@@ -369,7 +369,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 				from := acc.GetAddress()
 				coinAmount := sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(20))
 				amount := sdk.NewCoins(coinAmount)
-				gas := uint64(200000)
+				gas := uint64(300000)
 				txBuilder := suite.CreateTestEIP712MsgCreateValidator(from, privKey, "ethermint_9000-1", gas, amount)
 				return txBuilder.GetTx()
 			}, false, false, true,
@@ -380,7 +380,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 				from := acc.GetAddress()
 				coinAmount := sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(20))
 				amount := sdk.NewCoins(coinAmount)
-				gas := uint64(200000)
+				gas := uint64(300000)
 				txBuilder := suite.CreateTestEIP712MsgCreateValidator2(from, privKey, "ethermint_9000-1", gas, amount)
 				return txBuilder.GetTx()
 			}, false, false, true,

--- a/evmd/ante/evm_handler.go
+++ b/evmd/ante/evm_handler.go
@@ -55,6 +55,7 @@ func newLegacyCosmosAnteHandlerEip712(ctx sdk.Context, options HandlerOptions, e
 		cosmos.NewLegacyEip712SigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		authante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
+		cosmos.NewFixedGasConsumedDecorator(),
 	}
 	decorators = append(decorators, extra...)
 	return sdk.ChainAnteDecorators(decorators...)

--- a/evmd/ante/fixed_gas_test.go
+++ b/evmd/ante/fixed_gas_test.go
@@ -1,0 +1,330 @@
+package ante_test
+
+import (
+	"fmt"
+
+	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	cosmosante "github.com/evmos/ethermint/ante/cosmos"
+	utiltx "github.com/evmos/ethermint/testutil/tx"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+)
+
+func (suite *AnteTestSuite) TestFixedGasConsumedDecorator() {
+	decorator := cosmosante.NewFixedGasConsumedDecorator()
+
+	addr := sdk.AccAddress(suite.priv.PubKey().Address().Bytes())
+
+	valAddr := sdk.ValAddress(addr)
+
+	valPubKey := ed25519.GenPrivKey().PubKey()
+
+	testCases := []struct {
+		name                string
+		msgs                []sdk.Msg
+		expectedFixedGas    uint64
+		expectFixedGasMeter bool
+	}{
+		{
+			name: "non-whitelisted message - MsgSend",
+			msgs: []sdk.Msg{
+				banktypes.NewMsgSend(
+					addr,
+					sdk.AccAddress([]byte("recipient_address")),
+					sdk.NewCoins(sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(100))),
+				),
+			},
+			expectedFixedGas:    0,
+			expectFixedGasMeter: false,
+		},
+		{
+			name: "non-whitelisted message - MsgUpdateParams",
+			msgs: []sdk.Msg{
+				&stakingtypes.MsgUpdateParams{
+					Authority: suite.app.StakingKeeper.GetAuthority(),
+					Params:    stakingtypes.DefaultParams(),
+				},
+			},
+			expectedFixedGas:    0,
+			expectFixedGasMeter: false,
+		},
+		{
+			name: "non-whitelisted message - MsgDelegate",
+			msgs: []sdk.Msg{
+				stakingtypes.NewMsgDelegate(
+					addr.String(),
+					valAddr.String(),
+					sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(1000)),
+				),
+			},
+			expectedFixedGas:    0,
+			expectFixedGasMeter: false,
+		},
+		{
+			name: "non-whitelisted message - MsgEditValidator",
+			msgs: []sdk.Msg{
+				stakingtypes.NewMsgEditValidator(
+					valAddr.String(),
+					stakingtypes.NewDescription("moniker", "identity", "website", "security", "details"),
+					nil,
+					nil,
+				),
+			},
+			expectedFixedGas:    0,
+			expectFixedGasMeter: false,
+		},
+		{
+			name: "whitelisted message - MsgCreateValidator",
+			msgs: []sdk.Msg{
+				func() sdk.Msg {
+					msg, _ := stakingtypes.NewMsgCreateValidator(
+						valAddr.String(),
+						valPubKey,
+						sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(1000)),
+						stakingtypes.NewDescription("moniker", "identity", "website", "security", "details"),
+						stakingtypes.NewCommissionRates(
+							sdkmath.LegacyNewDecWithPrec(1, 1),
+							sdkmath.LegacyNewDecWithPrec(2, 1),
+							sdkmath.LegacyNewDecWithPrec(1, 2),
+						),
+						sdkmath.NewInt(1000),
+					)
+					return msg
+				}(),
+			},
+			expectedFixedGas:    0,
+			expectFixedGasMeter: false,
+		},
+		{
+			name: "non-whitelisted message - MsgCancelUnbondingDelegation",
+			msgs: []sdk.Msg{
+				stakingtypes.NewMsgCancelUnbondingDelegation(
+					addr.String(),
+					valAddr.String(),
+					1,
+					sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(1000)),
+				),
+			},
+			expectedFixedGas:    0,
+			expectFixedGasMeter: false,
+		},
+		{
+			name: "whitelisted message - MsgUndelegate",
+			msgs: []sdk.Msg{
+				stakingtypes.NewMsgUndelegate(
+					addr.String(),
+					valAddr.String(),
+					sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(1000)),
+				),
+			},
+			expectedFixedGas:    cosmosante.WhitelistedMessages[sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{})],
+			expectFixedGasMeter: true,
+		},
+		{
+			name: "whitelisted message - MsgBeginRedelegate",
+			msgs: []sdk.Msg{
+				stakingtypes.NewMsgBeginRedelegate(
+					addr.String(),
+					valAddr.String(),
+					valAddr.String(),
+					sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(1000)),
+				),
+			},
+			expectedFixedGas:    cosmosante.WhitelistedMessages[sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{})],
+			expectFixedGasMeter: true,
+		},
+	
+		{
+			name: "multiple whitelisted messages - MsgBeginRedelegate + MsgUndelegate",
+			msgs: []sdk.Msg{
+				stakingtypes.NewMsgBeginRedelegate(
+					addr.String(),
+					valAddr.String(),
+					valAddr.String(),
+					sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(1000)),
+				),
+				stakingtypes.NewMsgUndelegate(
+					addr.String(),
+					valAddr.String(),
+					sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(500)),
+				),
+			},
+			expectedFixedGas:    cosmosante.WhitelistedMessages[sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{})] + cosmosante.WhitelistedMessages[sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{})],
+			expectFixedGasMeter: true,
+		},
+		{
+			name: "mixed messages - whitelisted and non-whitelisted",
+			msgs: []sdk.Msg{
+				stakingtypes.NewMsgBeginRedelegate(
+					addr.String(),
+					valAddr.String(),
+					valAddr.String(),
+					sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(1000)),
+				),
+				banktypes.NewMsgSend(
+					addr,
+					sdk.AccAddress([]byte("recipient_address")),
+					sdk.NewCoins(sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(100))),
+				),
+			},
+			expectedFixedGas:    cosmosante.WhitelistedMessages[sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{})], // additional fixed gas consumed should only be for the whitelisted one
+			expectFixedGasMeter: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.SetupTest()
+
+			args := utiltx.CosmosTxArgs{
+				TxCfg:      suite.clientCtx.TxConfig,
+				Priv:       suite.priv,
+				Gas:        1000000,
+				FeeGranter: addr,
+				Msgs:       tc.msgs,
+			}
+
+			tx, err := utiltx.PrepareCosmosTx(suite.ctx, suite.app, args)
+			suite.Require().NoError(err)
+
+			gasLimit := uint64(1000000)
+			gasMeter := storetypes.NewGasMeter(gasLimit)
+			ctx := suite.ctx.WithGasMeter(gasMeter)
+
+			// Record initial gas consumed (from any setup)
+			initialGas := ctx.GasMeter().GasConsumed()
+
+			newCtx, err := decorator.AnteHandle(ctx, tx, false, NextFn)
+
+			suite.Require().NoError(err)
+
+			// Check if fixed gas was consumed correctly
+			gasConsumed := newCtx.GasMeter().GasConsumed()
+
+			if tc.expectFixedGasMeter {
+				// When fixed gas meter is used, the gas consumed should equal
+				// the initial gas plus the expected fixed gas
+				expectedTotalGas := initialGas + tc.expectedFixedGas
+				suite.Require().Equal(expectedTotalGas, gasConsumed,
+					"Expected gas consumed to be %d but got %d", expectedTotalGas, gasConsumed)
+
+				// Verify that the gas meter is now a fixed gas meter
+				// by trying to consume gas and checking it doesn't increase
+				gasBefore := newCtx.GasMeter().GasConsumed()
+				newCtx.GasMeter().ConsumeGas(1000, "test consume")
+				gasAfter := newCtx.GasMeter().GasConsumed()
+				suite.Require().Equal(gasBefore, gasAfter,
+					"Fixed gas meter should not consume additional gas")
+
+				// Verify the gas meter limit equals consumed amount
+				suite.Require().Equal(gasConsumed, newCtx.GasMeter().Limit(),
+					"Fixed gas meter limit should equal consumed gas")
+
+				// Verify gas meter never reports out of gas
+				suite.Require().False(newCtx.GasMeter().IsOutOfGas(),
+					"Fixed gas meter should never be out of gas")
+				suite.Require().False(newCtx.GasMeter().IsPastLimit(),
+					"Fixed gas meter should never be past limit")
+			} else {
+				// When no fixed gas meter is used, the gas meter should still
+				// be able to consume gas normally
+				gasBefore := newCtx.GasMeter().GasConsumed()
+				testGasAmount := uint64(1000)
+				newCtx.GasMeter().ConsumeGas(testGasAmount, "test consume")
+				gasAfter := newCtx.GasMeter().GasConsumed()
+				suite.Require().Equal(gasBefore+testGasAmount, gasAfter,
+					"Regular gas meter should consume gas normally")
+			}
+		})
+	}
+}
+
+func (suite *AnteTestSuite) TestFixedGasMeter() {
+	testCases := []struct {
+		name           string
+		consumedGas    uint64
+		testOperations func(*AnteTestSuite, storetypes.GasMeter)
+	}{
+		{
+			name:        "GasConsumed returns fixed amount",
+			consumedGas: 100000,
+			testOperations: func(s *AnteTestSuite, gm storetypes.GasMeter) {
+				s.Require().Equal(uint64(100000), gm.GasConsumed())
+			},
+		},
+		{
+			name:        "GasConsumedToLimit returns fixed amount",
+			consumedGas: 100000,
+			testOperations: func(s *AnteTestSuite, gm storetypes.GasMeter) {
+				s.Require().Equal(uint64(100000), gm.GasConsumedToLimit())
+			},
+		},
+		{
+			name:        "GasRemaining returns zero",
+			consumedGas: 100000,
+			testOperations: func(s *AnteTestSuite, gm storetypes.GasMeter) {
+				s.Require().Equal(uint64(0), gm.GasRemaining())
+			},
+		},
+		{
+			name:        "Limit equals consumed gas",
+			consumedGas: 250000,
+			testOperations: func(s *AnteTestSuite, gm storetypes.GasMeter) {
+				s.Require().Equal(uint64(250000), gm.Limit())
+			},
+		},
+		{
+			name:        "ConsumeGas does not change gas consumed",
+			consumedGas: 100000,
+			testOperations: func(s *AnteTestSuite, gm storetypes.GasMeter) {
+				before := gm.GasConsumed()
+				gm.ConsumeGas(50000, "test")
+				after := gm.GasConsumed()
+				s.Require().Equal(before, after)
+			},
+		},
+		{
+			name:        "RefundGas does not change gas consumed",
+			consumedGas: 100000,
+			testOperations: func(s *AnteTestSuite, gm storetypes.GasMeter) {
+				before := gm.GasConsumed()
+				gm.RefundGas(10000, "test")
+				after := gm.GasConsumed()
+				s.Require().Equal(before, after)
+			},
+		},
+		{
+			name:        "IsPastLimit always returns false",
+			consumedGas: 100000,
+			testOperations: func(s *AnteTestSuite, gm storetypes.GasMeter) {
+				s.Require().False(gm.IsPastLimit())
+			},
+		},
+		{
+			name:        "IsOutOfGas always returns false",
+			consumedGas: 100000,
+			testOperations: func(s *AnteTestSuite, gm storetypes.GasMeter) {
+				s.Require().False(gm.IsOutOfGas())
+			},
+		},
+		{
+			name:        "String returns correct identifier",
+			consumedGas: 100000,
+			testOperations: func(s *AnteTestSuite, gm storetypes.GasMeter) {
+				s.Require().Equal("fixedGasMeter", gm.String())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			gm := cosmosante.NewFixedGasMeter(tc.consumedGas)
+			tc.testOperations(suite, gm)
+		})
+	}
+}

--- a/evmd/ante/handler_options.go
+++ b/evmd/ante/handler_options.go
@@ -201,6 +201,7 @@ func newCosmosAnteHandler(ctx sdk.Context, options HandlerOptions, extra ...sdk.
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
+		cosmos.NewFixedGasConsumedDecorator(),
 	}
 	decorators = append(decorators, extra...)
 	return sdk.ChainAnteDecorators(decorators...)

--- a/evmd/app.go
+++ b/evmd/app.go
@@ -210,9 +210,10 @@ type EthermintApp struct {
 	pendingTxListeners []ante.PendingTxListener
 
 	// keys to access the substores
-	keys  map[string]*storetypes.KVStoreKey
-	tkeys map[string]*storetypes.TransientStoreKey
-	okeys map[string]*storetypes.ObjectStoreKey
+	keys    map[string]*storetypes.KVStoreKey
+	tkeys   map[string]*storetypes.TransientStoreKey
+	okeys   map[string]*storetypes.ObjectStoreKey
+	memKeys map[string]*storetypes.MemoryStoreKey
 
 	// keepers
 	AccountKeeper         authkeeper.AccountKeeper
@@ -311,7 +312,7 @@ func NewEthermintApp(
 	// Add the EVM transient store key
 	tkeys := storetypes.NewTransientStoreKeys(paramstypes.TStoreKey)
 	okeys := storetypes.NewObjectStoreKeys(banktypes.ObjectStoreKey, evmtypes.ObjectStoreKey)
-
+	memKeys := storetypes.NewMemoryStoreKeys(stakingtypes.CacheStoreKey)
 	// load state streaming if enabled
 	if err := bApp.RegisterStreamingServices(appOpts, keys); err != nil {
 		fmt.Printf("failed to load state streaming: %s", err)
@@ -328,6 +329,7 @@ func NewEthermintApp(
 		keys:              keys,
 		tkeys:             tkeys,
 		okeys:             okeys,
+		memKeys:           memKeys,
 	}
 
 	// init params keeper and subspaces
@@ -378,14 +380,17 @@ func NewEthermintApp(
 		panic(err)
 	}
 	app.txConfig = txConfig
+	stakingCacheSize := cast.ToInt(appOpts.Get(server.FlagStakingCacheSize))
 	app.StakingKeeper = stakingkeeper.NewKeeper(
 		appCodec,
 		runtime.NewKVStoreService(keys[stakingtypes.StoreKey]),
+		runtime.NewMemStoreService(memKeys[stakingtypes.CacheStoreKey]),
 		app.AccountKeeper,
 		app.BankKeeper,
 		authAddr,
 		address.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
 		address.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
+		stakingCacheSize,
 	)
 	app.MintKeeper = mintkeeper.NewKeeper(
 		appCodec,
@@ -738,6 +743,7 @@ func NewEthermintApp(
 	app.MountKVStores(keys)
 	app.MountTransientStores(tkeys)
 	app.MountObjectStores(okeys)
+	app.MountMemoryStores(memKeys)
 
 	// initialize BaseApp
 	app.SetInitChainer(app.InitChainer)

--- a/go.mod
+++ b/go.mod
@@ -277,7 +277,7 @@ replace (
 	// release/v0.50.x
 	cosmossdk.io/store => github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20241217090828-cfbca9fe8254
 	cosmossdk.io/x/tx => github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20241217090828-cfbca9fe8254
-	github.com/cosmos/cosmos-sdk => github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20250424063720-28ea58ae20d8
+	github.com/cosmos/cosmos-sdk => github.com/randy-cro/cosmos-sdk v0.0.0-20251121082545-b3fa9253c274
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -895,8 +895,6 @@ github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c h1:MOgfS4+F
 github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/crypto-org-chain/cometbft v0.0.0-20241106091515-ce418f845d9a h1:0EN1TkzHTAxpgpGaZJY3G7L4jf4+sYnI7FOmBFLCg4U=
 github.com/crypto-org-chain/cometbft v0.0.0-20241106091515-ce418f845d9a/go.mod h1:khbgmtxbgwJfMqDmnGY4rl2sQpTdzpPb1f9nqnfpy1o=
-github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20250424063720-28ea58ae20d8 h1:Sif0pGNc4C384OLucyQ7P/+KjYiJ6uDn8Cf8wR7MI+c=
-github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20250424063720-28ea58ae20d8/go.mod h1:JwwsMeZldLN20b72mmbWPY0EV9rs+v/12hRu1JFttvY=
 github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20241217090828-cfbca9fe8254 h1:NEgy0r3otU/O+0OAjMdEhbn4VotQlg+98hHbD7M23wU=
 github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20241217090828-cfbca9fe8254/go.mod h1:8DwVTz83/2PSI366FERGbWSH7hL6sB7HbYp8bqksNwM=
 github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20241217090828-cfbca9fe8254 h1:JzLOFRiKsDtLJt5h0M0jkEIPDKvFFyja7VEp7gG6O9U=
@@ -1585,6 +1583,8 @@ github.com/prometheus/procfs v0.3.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/randy-cro/cosmos-sdk v0.0.0-20251121082545-b3fa9253c274 h1:yp9qOCeO8cwlz+CAg5fcHgklfbp6aGgTl3tkuoI9VNI=
+github.com/randy-cro/cosmos-sdk v0.0.0-20251121082545-b3fa9253c274/go.mod h1:8/AdT5lF3ILCCl/sDQXyBgzWGtcmD1tInWyhYeREVPA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -210,9 +210,9 @@ schema = 3
     version = "v1.0.0-beta.5"
     hash = "sha256-Fy/PbsOsd6iq0Njy3DVWK6HqWsogI+MkE8QslHGWyVg="
   [mod."github.com/cosmos/cosmos-sdk"]
-    version = "v0.50.6-0.20250424063720-28ea58ae20d8"
-    hash = "sha256-UCynFh2IangiNqQsgux4dKCk8wuF1vgoINQGA8N59QY="
-    replaced = "github.com/crypto-org-chain/cosmos-sdk"
+    version = "v0.0.0-20251121082545-b3fa9253c274"
+    hash = "sha256-XzBX/BIFpKZWMBqyGML0RpSBHMnQu1QVY9+dMi85mws="
+    replaced = "github.com/randy-cro/cosmos-sdk"
   [mod."github.com/cosmos/go-bip39"]
     version = "v1.0.0"
     hash = "sha256-Qm2aC2vaS8tjtMUbHmlBSagOSqbduEEDwc51qvQaBmA="


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This patch introduces a **fixed gas consumption decorator** in the **antehandler** to standardize gas usage for **whitelisted messages**.  
Currently, only **staking-related messages** are included in the whitelist.

## Purpose

This ensures **consistent gas consumption across all nodes**, regardless of variations in **staking cache size**.  
By normalizing gas usage, it prevents potential **AppHash mismatches** caused by potential node-specific cache sizes.

## Implementation Details

- A **fixed gas amount** is assigned per whitelisted message type.  
- The values are derived from the **average gas usage observed on mainnet**.  

For example, the mean gas used for `MsgUndelegate` can be referenced here:  
[Mainnet reference](https://rest.cronos.org/cosmos/tx/v1beta1/txs?query=message.action=%27%2Fcosmos.staking.v1beta1.MsgUndelegate%27&pagination.limit=10000)

This change works **in tandem with the staking cache** introduced in the Cosmos SDK:  
[crypto-org-chain/cosmos-sdk#1733](https://github.com/crypto-org-chain/cosmos-sdk/pull/1733)

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
