### PR TITLE
fix: nonce increments on EIP-7702 contract creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (rpc) [#804](https://github.com/crypto-org-chain/ethermint/pull/804) fix: add allow-unprotected-txs config
 * (evm) [#809](https://github.com/crypto-org-chain/ethermint/pull/809) fix: relax preinstall rules
 * (rpc) [#814](https://github.com/crypto-org-chain/ethermint/pull/814) fix: estimate gas not accurate
+* (evm) [#815](https://github.com/crypto-org-chain/ethermint/pull/815) fix: nonce increments on EIP-7702 contract creation
 
 ## [v0.22.0] - 2025-08-12
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,22 +7,16 @@
 import sources.nixpkgs {
   overlays = [
     (import ./build_overlay.nix)
-    (final: super: rec {
+    (final: super: {
       flake-compat = import sources.flake-compat;
-      # Create a Go 1.25 specific builder without overriding buildGoModule
-      buildGo125 = super.go_1_25;
-      buildGo125Module = super.callPackage "${super.path}/pkgs/build-support/go/module.nix" {
-        go = buildGo125;
-      };
+      # In nixpkgs 25.11 with go = go_1_25 (set in build_overlay.nix),
+      # buildGoModule already uses Go 1.25, so we just use it directly
       go-ethereum = final.callPackage ./go-ethereum.nix {
         # Skip darwin-specific dependencies to avoid apple_sdk_11_0 errors in nixpkgs 25.11
         libobjc = null;
         IOKit = null;
-        buildGoModule = buildGo125Module;
       };
-      golangci-lint = final.callPackage ./golangci-lint.nix {
-        buildGo125Module = buildGo125Module;
-      };
+      golangci-lint = final.callPackage ./golangci-lint.nix { };
     }) # update to a version that supports eip-1559
     (import "${sources.poetry2nix}/overlay.nix")
     # Fix poetry2nix compatibility with nixpkgs 25.11 - override fetchCargoTarball usage
@@ -73,7 +67,7 @@ import sources.nixpkgs {
     )
     (_: pkgs: { test-env = pkgs.callPackage ./testenv.nix { }; })
     (_: pkgs: {
-      cosmovisor = (pkgs.buildGo125Module or (pkgs.buildGoModule.override { go = pkgs.go_1_25; })) rec {
+      cosmovisor = pkgs.buildGoModule rec {
         name = "cosmovisor";
         src = sources.cosmos-sdk + "/cosmovisor";
         subPackages = [ "./cmd/cosmovisor" ];

--- a/nix/golangci-lint.nix
+++ b/nix/golangci-lint.nix
@@ -1,11 +1,11 @@
 {
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitHub,
   lib,
   installShellFiles,
 }:
 
-buildGo125Module rec {
+buildGoModule rec {
   pname = "golangci-lint";
   version = "2.1.6";
 

--- a/tests/integration_tests/hardhat/contracts/DelegationTarget.sol
+++ b/tests/integration_tests/hardhat/contracts/DelegationTarget.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title DelegationTarget
+ * @notice Minimal contract for EIP-7702 delegation that allows deploying other contracts
+ * @dev This contract can be set as a delegation target for an EOA via EIP-7702
+ */
+contract DelegationTarget {
+    // Storage slot where the counter (last offset) is stored
+    uint256 constant COUNTER_SLOT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+
+    event ContractDeployed(address indexed deployed, bytes32 salt);
+    event ContractDestroyed(address indexed destroyed, uint256 index, bool success);
+    event CodeHash(address indexed deployed, bytes32 codeHash);
+
+    /**
+     * @notice Deploy a contract using CREATE
+     * @param bytecode The bytecode of the contract to deploy
+     * @return deployed The address of the deployed contract
+     * @dev Stores deployed addresses at slots 0, 1, 2, ... and counter at COUNTER_SLOT
+     */
+    function deploy(bytes memory bytecode) external returns (address deployed) {
+        assembly {
+            deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            // Load current counter from COUNTER_SLOT
+            let currentSlot := sload(COUNTER_SLOT)
+            // Store deployed address at slot currentSlot (0, 1, 2, ...)
+            sstore(currentSlot, deployed)
+            // Increment counter and store back
+            sstore(COUNTER_SLOT, add(currentSlot, 1))
+        }
+        require(deployed != address(0), "Deployment failed");
+        emit ContractDeployed(deployed, bytes32(0));
+    }
+
+    /**
+     * @notice Get the deployed address at a given index
+     * @param index The index (slot) to read from
+     * @return addr The deployed address
+     */
+    function getDeployedAt(uint256 index) external view returns (address addr) {
+        assembly {
+            addr := sload(index)
+        }
+    }
+
+    /**
+     * @notice Get the current counter (number of deployments)
+     * @return count The number of deployed contracts
+     */
+    function getDeploymentCount() external view returns (uint256 count) {
+        assembly {
+            count := sload(COUNTER_SLOT)
+        }
+    }
+
+    /**
+     * @notice Selfdestruct all deployed contracts
+     * @dev Calls destroy() on each deployed contract. Contracts must implement destroy() with selfdestruct
+     */
+    function selfdestructAll() external {
+        uint256 count;
+        assembly {
+            count := sload(COUNTER_SLOT)
+        }
+
+        for (uint256 i = 0; i < count; i++) {
+            address target;
+            assembly {
+                target := sload(i)
+            }
+            // Call destroy() selector: 0x83197ef0
+            (bool success,) = target.call(abi.encodeWithSelector(MinimalContract.selfDestruct.selector));
+            emit ContractDestroyed(target, i, success);
+        }
+    }
+
+    function emitAllCodeHashes() external {
+        uint256 count;
+        assembly {
+            count := sload(COUNTER_SLOT)
+        }
+
+        for (uint256 i = 0; i < count; i++) {
+            address target;
+            assembly {
+                target := sload(i)
+            }
+            bytes32 codeHash;
+            assembly {
+                codeHash := extcodehash(target)
+            }
+            emit CodeHash(target, codeHash);
+        }
+    }
+
+    /**
+     * @notice Execute arbitrary call (useful for delegated EOA)
+     * @param target The target address
+     * @param data The calldata
+     * @return success Whether the call succeeded
+     * @return result The return data
+     */
+    function execute(address target, bytes calldata data) external payable returns (bool success, bytes memory result) {
+        (success, result) = target.call{value: msg.value}(data);
+    }
+
+    receive() external payable {}
+}
+
+
+
+
+/**
+ * @title MinimalContract
+ * @notice A minimal contract that gets deployed by MaliciousDeployer
+ */
+contract MinimalContract {
+    address public immutable creator;
+    uint256 public value;
+
+    constructor() {
+        creator = msg.sender;
+    }
+
+    function setValue(uint256 _value) external {
+        value = _value;
+    }
+
+    function selfDestruct() external {
+        selfdestruct(payable(creator));
+    }
+}
+
+/**
+ * @title FinalContract
+ * @notice The final contract that gets deployed by MaliciousDeployer
+ */
+contract FinalContract {
+    address public immutable creator;
+    uint256 public value;
+
+    constructor() {
+        creator = msg.sender;
+    }
+
+    function singletonFunction() external pure returns (string memory) {
+        return "I am the final contract!";
+    }
+}

--- a/tests/integration_tests/hardhat/contracts/MaliciousDeployer.sol
+++ b/tests/integration_tests/hardhat/contracts/MaliciousDeployer.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./DelegationTarget.sol";
+
+/**
+ * @title MaliciousDeployer
+ * @notice Contract that during deployment calls back the deployer (with EIP-7702 delegation)
+ *         and deploys contracts through the delegated EOA
+ * @dev The constructor performs the callback attack during deployment
+ */
+contract MaliciousDeployer {
+    address public immutable deployer;
+    address[] public deployedContracts;
+
+    event CallbackExecuted(address indexed delegatedEOA, bool success);
+    event ContractDeployedViaCallback(address indexed deployed);
+
+    /**
+     * @notice Constructor that calls back the deployer and deploys contracts
+     * @param delegatedEOA The EOA with EIP-7702 delegation (should be tx.origin or specified)
+     * @param numContracts Number of contracts to deploy via callback
+     */
+    constructor(address delegatedEOA, uint256 numContracts, uint256 step) {
+        deployer = msg.sender;
+
+        // Attempt to call back the delegated EOA and deploy contracts through it
+        for (uint256 i = 0; i < numContracts; i++) {
+            // Get bytecode for MinimalContract
+            bytes memory bytecode;
+            if (step == 1) {
+                bytecode = type(MinimalContract).creationCode;
+            } else {
+                bytecode = type(FinalContract).creationCode;
+            }
+
+            // Call the deploy function on the delegated EOA (which has DelegationTarget code)
+            (bool success, bytes memory result) = delegatedEOA.call(
+                abi.encodeWithSelector(DelegationTarget.deploy.selector, bytecode)
+            );
+
+            emit CallbackExecuted(delegatedEOA, success);
+            address deployed;
+            if (success && result.length >= 32) {
+                deployed = abi.decode(result, (address));
+                deployedContracts.push(deployed);
+            }
+        }
+
+        delegatedEOA.call(abi.encodeWithSelector(DelegationTarget.emitAllCodeHashes.selector));
+
+
+        // @audit at this point, the attacker can make external calls
+
+
+        // Call the deploy function on the delegated EOA (which has DelegationTarget code)
+        if (step == 1) {
+            delegatedEOA.call(
+                abi.encodeWithSelector(DelegationTarget.selfdestructAll.selector)
+            );
+        }
+    }
+
+    /**
+     * @notice Get the number of contracts deployed via callback
+     */
+    function getDeployedCount() external view returns (uint256) {
+        return deployedContracts.length;
+    }
+
+    /**
+     * @notice Get all deployed contract addresses
+     */
+    function getDeployedContracts() external view returns (address[] memory) {
+        return deployedContracts;
+    }
+}

--- a/tests/integration_tests/shell.nix
+++ b/tests/integration_tests/shell.nix
@@ -15,5 +15,9 @@ pkgs.mkShell {
   ];
   shellHook = ''
     . ${../../scripts/env}
+    # Fix poetry2nix Python environment in nixpkgs 25.11
+    # The wrapper binary doesn't set PYTHONHOME, causing sys.prefix to point
+    # to the base python instead of the poetry environment
+    export PYTHONHOME="${pkgs.test-env}"
   '';
 }

--- a/tests/integration_tests/test_set_code_tx.py
+++ b/tests/integration_tests/test_set_code_tx.py
@@ -10,7 +10,14 @@ from web3 import Web3, exceptions
 
 from .bytecode_deployer import deploy_runtime_bytecode
 from .network import setup_custom_ethermint
-from .utils import derive_new_account, fund_acc, send_transaction
+from .utils import (
+    CONTRACTS,
+    deploy_contract,
+    derive_new_account,
+    fund_acc,
+    send_transaction,
+    w3_wait_for_new_blocks,
+)
 
 DELEGATION_PREFIX = "0xef0100"
 
@@ -704,3 +711,95 @@ def test_set_code_tx_revoke_delegation(cluster):
     assert (
         Web3.to_hex(code) == expected_code
     ), f"Expected code {expected_code}, got {Web3.to_hex(code)}"
+
+
+def test_eip7702_nonce_increment(cluster):
+    """
+    TestEIP7702NonceIncrement equivalent: Tests that when a user with EIP-7702
+    delegation deploys a contract whose constructor calls back to the user
+    (via the delegation) and deploys more contracts, the user's nonce is
+    correctly incremented.
+
+    This test reproduces a bug where the nonce was unconditionally reset to msg.Nonce+1
+    after evm.Create(), ignoring any nonce increments that occurred during execution.
+
+    Bug scenario:
+    1. User (with EIP-7702 delegation) sends contract creation tx with nonce N
+    2. evm.Create() increments User's nonce to N+1
+    3. Constructor calls back to User via delegation, deploying more contracts
+    4. Each nested CREATE increments User's nonce (N+2, N+3, ...)
+    5. BUG: After evm.Create() returns, nonce is reset to N+1, losing all increments
+    """
+    w3 = cluster.w3
+    chain_id = w3.eth.chain_id
+
+    user = derive_new_account(n=100)
+    helper = derive_new_account(n=101)
+
+    fund_acc(w3, user)
+    fund_acc(w3, helper)
+
+    delegation_target_contract, _ = deploy_contract(
+        w3, CONTRACTS["DelegationTarget"], key=helper.key
+    )
+    delegation_target_addr = delegation_target_contract.address
+
+    w3_wait_for_new_blocks(w3, 1)
+
+    user_nonce = w3.eth.get_transaction_count(user.address)
+
+    auth = {
+        "chainId": chain_id,
+        "address": delegation_target_addr,
+        "nonce": user_nonce + 1,
+    }
+    signed_auth = user.sign_authorization(auth)
+
+    setcode_tx = {
+        "chainId": chain_id,
+        "type": 4,
+        "to": user.address,
+        "value": 0,
+        "gas": 100000,
+        "maxFeePerGas": 1000000000000,
+        "maxPriorityFeePerGas": 10000,
+        "nonce": user_nonce,
+        "authorizationList": [signed_auth],
+    }
+
+    signed_tx = user.sign_transaction(setcode_tx)
+    tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
+    assert receipt.status == 1, f"SetCode transaction failed: {receipt}"
+
+    w3_wait_for_new_blocks(w3, 1)
+
+    code = w3.eth.get_code(user.address, "latest")
+    expected_delegation = address_to_delegation(delegation_target_addr)
+    assert code == HexBytes(expected_delegation), (
+        f"Delegation not set correctly: got {Web3.to_hex(code)}, "
+        f"want {expected_delegation}"
+    )
+
+    initial_nonce = w3.eth.get_transaction_count(user.address)
+
+    num_contracts = 30
+    step = 1
+
+    deploy_contract(
+        w3,
+        CONTRACTS["MaliciousDeployer"],
+        args=(user.address, num_contracts, step),
+        key=user.key,
+    )
+
+    w3_wait_for_new_blocks(w3, 1)
+
+    final_nonce = w3.eth.get_transaction_count(user.address)
+
+    expected_nonce = initial_nonce + 1 + num_contracts
+    assert final_nonce == expected_nonce, (
+        f"user nonce should be {expected_nonce} "
+        f"(initial {initial_nonce} + 1 for deployment + "
+        f"{num_contracts} nested creates), but got {final_nonce}"
+    )

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -49,6 +49,8 @@ TEST_CONTRACTS = {
     "SelfDestruct": "SelfDestruct.sol",
     "BytecodeDeployer": "BytecodeDeployer.sol",
     "GasConsumerTryCatch": "GasConsumerTryCatch.sol",
+    "DelegationTarget": "DelegationTarget.sol",
+    "MaliciousDeployer": "MaliciousDeployer.sol",
 }
 
 

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -429,13 +429,17 @@ func (k *Keeper) ApplyMessageWithConfig(
 	stateDB.Prepare(rules, msg.From, cfg.CoinBase, msg.To, vm.ActivePrecompiles(rules), msg.AccessList)
 
 	if contractCreation {
-		// take over the nonce management from evm:
-		// - reset sender's nonce to msg.Nonce() to generate correct contract address.
-		// - set the nonce back to the original value after contract creation.
-		oldNonce := stateDB.GetNonce(sender)
+		// Reset sender's nonce to msg.Nonce so evm.Create() can:
+		// 1. Compute the correct contract address using crypto.CreateAddress(sender, nonce)
+		// 2. Increment the nonce correctly during execution
+		//
+		// Note: The ante handler has already incremented the nonce to msg.Nonce+1,
+		// but evm.Create() needs it at msg.Nonce to calculate addresses correctly.
+		// After evm.Create() returns, the nonce will be msg.Nonce+1 (for the main create)
+		// plus any additional increments from nested CREATEs (e.g., via EIP-7702 delegation
+		// callbacks). We preserve all these nonce changes - no need reset after creation.
 		stateDB.SetNonce(sender, msg.Nonce, tracing.NonceChangeUnspecified)
 		ret, _, leftoverGas, vmErr = evm.Create(sender, msg.Data, leftoverGas, uint256.MustFromBig(msg.Value))
-		stateDB.SetNonce(sender, oldNonce, tracing.NonceChangeUnspecified)
 	} else {
 		if msg.SetCodeAuthorizations != nil {
 			for _, auth := range msg.SetCodeAuthorizations {

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -429,17 +429,23 @@ func (k *Keeper) ApplyMessageWithConfig(
 	stateDB.Prepare(rules, msg.From, cfg.CoinBase, msg.To, vm.ActivePrecompiles(rules), msg.AccessList)
 
 	if contractCreation {
-		// Reset sender's nonce to msg.Nonce so evm.Create() can:
-		// 1. Compute the correct contract address using crypto.CreateAddress(sender, nonce)
-		// 2. Increment the nonce correctly during execution
+		// Take over nonce management from evm:
+		// - Reset sender's nonce to msg.Nonce so evm.Create() computes correct contract address
+		// - After evm.Create(), calculate the final nonce accounting for:
+		//   1. The ante handler's nonce increment (already in oldNonce)
+		//   2. Any additional nonce increments from nested CREATEs (e.g., via EIP-7702 callbacks)
 		//
-		// Note: The ante handler has already incremented the nonce to msg.Nonce+1,
-		// but evm.Create() needs it at msg.Nonce to calculate addresses correctly.
-		// After evm.Create() returns, the nonce will be msg.Nonce+1 (for the main create)
-		// plus any additional increments from nested CREATEs (e.g., via EIP-7702 delegation
-		// callbacks). We preserve all these nonce changes - no need reset after creation.
+		// This is important for batch transactions where ante handler pre-increments
+		// nonces for all messages, and for EIP-7702 where constructor callbacks can
+		// trigger additional contract deployments.
+		oldNonce := stateDB.GetNonce(sender)
 		stateDB.SetNonce(sender, msg.Nonce, tracing.NonceChangeUnspecified)
 		ret, _, leftoverGas, vmErr = evm.Create(sender, msg.Data, leftoverGas, uint256.MustFromBig(msg.Value))
+		// evm.Create() increments nonce from msg.Nonce to (msg.Nonce + 1 + nestedCreates)
+		// We need: oldNonce + nestedCreates
+		afterCreateNonce := stateDB.GetNonce(sender)
+		nestedCreates := afterCreateNonce - msg.Nonce - 1
+		stateDB.SetNonce(sender, oldNonce+nestedCreates, tracing.NonceChangeUnspecified)
 	} else {
 		if msg.SetCodeAuthorizations != nil {
 			for _, auth := range msg.SetCodeAuthorizations {


### PR DESCRIPTION
- nix fix
  - fix python packages couldn't be reference inside nix-shell, added PYTHONHOME export to fix the poetry2nix Python wrapper issue in nixpkgs 25.11
  - reduce nix shell entering time by removing the ${super.path} reference that was causing the entire nixpkgs source to be copied