### PR TITLE
feat(block-stm): move signature verification to the pre-estimation phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (ante) [#829](https://github.com/crypto-org-chain/ethermint/pull/829) fix: validate payload messages in legacy EIP-712
 * (evm) [#830](https://github.com/crypto-org-chain/ethermint/pull/830) fix: revert batch nonce management for call and create, align implementation with geth
+* (block-stm) [#838](https://github.com/crypto-org-chain/ethermint/pull/838) feat: Move signature verification to the pre-estimation phase
 
 ## [v0.23.0] - 2026-01-13
 

--- a/evmd/executor.go
+++ b/evmd/executor.go
@@ -102,6 +102,8 @@ func STMTxExecutor(
 			workers,
 			estimates,
 			func(txn blockstm.TxnIndex, ms blockstm.MultiStore) {
+				// only one of the concurrent incarnations gets the cache if there are any, otherwise execute without
+				// cache, concurrent incarnations should be rare.
 				cachePtr := incarnationCache[txn].Swap(nil)
 				cache := map[string]any(nil)
 				if cachePtr != nil {

--- a/evmd/executor.go
+++ b/evmd/executor.go
@@ -147,7 +147,9 @@ func preEstimateAndCacheSigResults(
 ) ([]sdk.Tx, []blockstm.MultiLocations) {
 	sdkCtx := sdk.NewContext(ms, cmtproto.Header{}, false, log.NewNopLogger())
 	func() {
-		defer func() { recover() }() // keep fallback sdkCtx if UnwrapSDKContext panics
+		defer func() {
+			_ = recover() // keep fallback sdkCtx if UnwrapSDKContext panics
+		}()
 		sdkCtx = sdk.UnwrapSDKContext(ctx)
 	}()
 

--- a/evmd/executor.go
+++ b/evmd/executor.go
@@ -3,6 +3,7 @@ package evmd
 import (
 	"context"
 	"io"
+	"math/big"
 	"sync"
 	"sync/atomic"
 
@@ -14,6 +15,10 @@ import (
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	evmante "github.com/evmos/ethermint/ante"
+	"github.com/evmos/ethermint/evmd/ante"
+	evmkeeper "github.com/evmos/ethermint/x/evm/keeper"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -39,6 +44,8 @@ func DefaultTxExecutor(_ context.Context,
 
 type evmKeeper interface {
 	GetParams(ctx sdk.Context) evmtypes.Params
+	ChainID() *big.Int
+	EVMBlockConfig(sdk.Context, *big.Int) (*evmkeeper.EVMBlockConfig, error)
 }
 
 func STMTxExecutor(
@@ -77,13 +84,41 @@ func STMTxExecutor(
 		}
 
 		var (
-			estimates []blockstm.MultiLocations
-			memTxs    []sdk.Tx
+			estimates     []blockstm.MultiLocations
+			memTxs        []sdk.Tx
+			sigVerResults []error // pre-verified signature results
 		)
 		if estimate {
-			// pre-estimation
-			evmDenom := evmKeeper.GetParams(sdk.NewContext(ms, cmtproto.Header{}, false, log.NewNopLogger())).EvmDenom
-			memTxs, estimates = preEstimates(txs, workers, authStore, bankStore, evmDenom, txDecoder)
+			// pre-estimation with parallel signature verification
+			sdkCtx := sdk.NewContext(ms, cmtproto.Header{}, false, log.NewNopLogger())
+			func() {
+				defer func() {
+					if recover() != nil {
+						// keep fallback sdkCtx created above
+					}
+				}()
+				sdkCtx = sdk.UnwrapSDKContext(ctx)
+			}()
+
+			evmParams := evmKeeper.GetParams(sdkCtx)
+			evmDenom := evmParams.EvmDenom
+
+			var ethSigner ethtypes.Signer
+			if blockCfg, err := evmKeeper.EVMBlockConfig(sdkCtx, evmKeeper.ChainID()); err == nil {
+				ethSigner = ethtypes.MakeSigner(blockCfg.ChainConfig, blockCfg.BlockNumber, blockCfg.BlockTime)
+			}
+
+			memTxs, estimates, sigVerResults = preEstimatesWithSigVerify(txs, workers, authStore, bankStore, evmDenom, txDecoder, ethSigner)
+
+			// Store pre-verified signature results in incarnation cache
+			for i, result := range sigVerResults {
+				if memTxs[i] != nil {
+					cache := incarnationCache[i].Load()
+					if cache != nil {
+						(*cache)[ante.EthSigVerificationResultCacheKey] = result
+					}
+				}
+			}
 		}
 
 		if err := blockstm.ExecuteBlockWithEstimates(
@@ -197,8 +232,23 @@ func (ms stmMultiStoreWrapper) GetObjKVStore(key storetypes.StoreKey) storetypes
 // preEstimates returns a static estimation of the written keys for each transaction.
 // NOTE: make sure it sync with the latest sdk logic when sdk upgrade.
 func preEstimates(txs [][]byte, workers, authStore, bankStore int, evmDenom string, txDecoder sdk.TxDecoder) ([]sdk.Tx, []blockstm.MultiLocations) {
+	memTxs, estimates, _ := preEstimatesWithSigVerify(txs, workers, authStore, bankStore, evmDenom, txDecoder, nil)
+	return memTxs, estimates
+}
+
+// preEstimatesWithSigVerify returns a static estimation of the written keys for each transaction,
+// and optionally pre-verifies Ethereum signatures in parallel to avoid redundant crypto.Ecrecover calls.
+// The signature verification results are returned to be stored in the incarnation cache.
+func preEstimatesWithSigVerify(
+	txs [][]byte,
+	workers, authStore, bankStore int,
+	evmDenom string,
+	txDecoder sdk.TxDecoder,
+	ethSigner ethtypes.Signer,
+) ([]sdk.Tx, []blockstm.MultiLocations, []error) {
 	memTxs := make([]sdk.Tx, len(txs))
 	estimates := make([]blockstm.MultiLocations, len(txs))
+	sigVerResults := make([]error, len(txs))
 
 	job := func(start, end int) {
 		for i := start; i < end; i++ {
@@ -208,6 +258,14 @@ func preEstimates(txs [][]byte, workers, authStore, bankStore int, evmDenom stri
 				continue
 			}
 			memTxs[i] = tx
+
+			// Pre-verify Ethereum signatures in parallel (expensive crypto.Ecrecover).
+			// Only run for MsgEthereumTx to avoid extra work on cosmos txs.
+			if ethSigner != nil {
+				if _, ok := tx.(*evmtypes.MsgEthereumTx); ok {
+					sigVerResults[i] = evmante.VerifyEthSig(tx, ethSigner)
+				}
+			}
 
 			feeTx, ok := tx.(sdk.FeeTx)
 			if !ok {
@@ -256,5 +314,5 @@ func preEstimates(txs [][]byte, workers, authStore, bankStore int, evmDenom stri
 	}
 	wg.Wait()
 
-	return memTxs, estimates
+	return memTxs, estimates, sigVerResults
 }

--- a/evmd/executor.go
+++ b/evmd/executor.go
@@ -77,44 +77,22 @@ func STMTxExecutor(
 			return nil, nil
 		}
 		results := make([]*abci.ExecTxResult, blockSize)
-		incarnationCache := make([]atomic.Pointer[map[string]any], blockSize)
-		for i := 0; i < blockSize; i++ {
-			m := make(map[string]any)
-			incarnationCache[i].Store(&m)
-		}
+		incarnationCache := initIncarnationCache(blockSize)
 
-		var (
-			estimates     []blockstm.MultiLocations
-			memTxs        []sdk.Tx
-			sigVerResults []error // pre-verified signature results
-		)
+		var estimates []blockstm.MultiLocations
+		var memTxs []sdk.Tx
 		if estimate {
-			// pre-estimation with parallel signature verification
-			sdkCtx := sdk.NewContext(ms, cmtproto.Header{}, false, log.NewNopLogger())
-			func() {
-				defer func() { recover() }() // keep fallback sdkCtx if UnwrapSDKContext panics
-				sdkCtx = sdk.UnwrapSDKContext(ctx)
-			}()
-
-			evmParams := evmKeeper.GetParams(sdkCtx)
-			evmDenom := evmParams.EvmDenom
-
-			var ethSigner ethtypes.Signer
-			if blockCfg, err := evmKeeper.EVMBlockConfig(sdkCtx, evmKeeper.ChainID()); err == nil {
-				ethSigner = ethtypes.MakeSigner(blockCfg.ChainConfig, blockCfg.BlockNumber, blockCfg.BlockTime)
-			}
-
-			memTxs, estimates, sigVerResults = preEstimatesWithSigVerify(txs, workers, authStore, bankStore, evmDenom, txDecoder, ethSigner)
-
-			// Store pre-verified signature results in incarnation cache
-			for i, result := range sigVerResults {
-				if memTxs[i] != nil {
-					cache := incarnationCache[i].Load()
-					if cache != nil {
-						(*cache)[ante.EthSigVerificationResultCacheKey] = result
-					}
-				}
-			}
+			memTxs, estimates = preEstimateAndCacheSigResults(
+				ctx,
+				ms,
+				txs,
+				workers,
+				authStore,
+				bankStore,
+				evmKeeper,
+				txDecoder,
+				incarnationCache,
+			)
 		}
 
 		if err := blockstm.ExecuteBlockWithEstimates(
@@ -125,13 +103,10 @@ func STMTxExecutor(
 			workers,
 			estimates,
 			func(txn blockstm.TxnIndex, ms blockstm.MultiStore) {
-				var cache map[string]any
-
-				// only one of the concurrent incarnations gets the cache if there are any, otherwise execute without
-				// cache, concurrent incarnations should be rare.
-				v := incarnationCache[txn].Swap(nil)
-				if v != nil {
-					cache = *v
+				cachePtr := incarnationCache[txn].Swap(nil)
+				cache := map[string]any(nil)
+				if cachePtr != nil {
+					cache = *cachePtr
 				}
 
 				var memTx sdk.Tx
@@ -140,8 +115,8 @@ func STMTxExecutor(
 				}
 				results[txn] = deliverTxWithMultiStore(int(txn), memTx, msWrapper{ms}, cache)
 
-				if v != nil {
-					incarnationCache[txn].Store(v)
+				if cachePtr != nil {
+					incarnationCache[txn].Store(cachePtr)
 				}
 			},
 		); err != nil {
@@ -150,6 +125,62 @@ func STMTxExecutor(
 
 		return evmtypes.PatchTxResponses(results), nil
 	}
+}
+
+func initIncarnationCache(blockSize int) []atomic.Pointer[map[string]any] {
+	incarnationCache := make([]atomic.Pointer[map[string]any], blockSize)
+	for i := 0; i < blockSize; i++ {
+		m := make(map[string]any)
+		incarnationCache[i].Store(&m)
+	}
+	return incarnationCache
+}
+
+func preEstimateAndCacheSigResults(
+	ctx context.Context,
+	ms storetypes.MultiStore,
+	txs [][]byte,
+	workers, authStore, bankStore int,
+	evmKeeper evmKeeper,
+	txDecoder sdk.TxDecoder,
+	incarnationCache []atomic.Pointer[map[string]any],
+) ([]sdk.Tx, []blockstm.MultiLocations) {
+	sdkCtx := sdk.NewContext(ms, cmtproto.Header{}, false, log.NewNopLogger())
+	func() {
+		defer func() { recover() }() // keep fallback sdkCtx if UnwrapSDKContext panics
+		sdkCtx = sdk.UnwrapSDKContext(ctx)
+	}()
+
+	evmParams := evmKeeper.GetParams(sdkCtx)
+	evmDenom := evmParams.EvmDenom
+
+	var ethSigner ethtypes.Signer
+	if blockCfg, err := evmKeeper.EVMBlockConfig(sdkCtx, evmKeeper.ChainID()); err == nil {
+		ethSigner = ethtypes.MakeSigner(blockCfg.ChainConfig, blockCfg.BlockNumber, blockCfg.BlockTime)
+	}
+
+	memTxs, estimates, sigVerResults := preEstimatesWithSigVerify(
+		txs,
+		workers,
+		authStore,
+		bankStore,
+		evmDenom,
+		txDecoder,
+		ethSigner,
+	)
+
+	for i, result := range sigVerResults {
+		if memTxs[i] == nil {
+			continue
+		}
+		cache := incarnationCache[i].Load()
+		if cache == nil {
+			continue
+		}
+		(*cache)[ante.EthSigVerificationResultCacheKey] = result
+	}
+
+	return memTxs, estimates
 }
 
 type msWrapper struct {

--- a/evmd/executor.go
+++ b/evmd/executor.go
@@ -92,11 +92,7 @@ func STMTxExecutor(
 			// pre-estimation with parallel signature verification
 			sdkCtx := sdk.NewContext(ms, cmtproto.Header{}, false, log.NewNopLogger())
 			func() {
-				defer func() {
-					if recover() != nil {
-						// keep fallback sdkCtx created above
-					}
-				}()
+				defer func() { recover() }() // keep fallback sdkCtx if UnwrapSDKContext panics
 				sdkCtx = sdk.UnwrapSDKContext(ctx)
 			}()
 
@@ -227,13 +223,6 @@ func (ms stmMultiStoreWrapper) GetKVStore(key storetypes.StoreKey) storetypes.KV
 
 func (ms stmMultiStoreWrapper) GetObjKVStore(key storetypes.StoreKey) storetypes.ObjKVStore {
 	return ms.MultiStore.GetObjKVStore(key)
-}
-
-// preEstimates returns a static estimation of the written keys for each transaction.
-// NOTE: make sure it sync with the latest sdk logic when sdk upgrade.
-func preEstimates(txs [][]byte, workers, authStore, bankStore int, evmDenom string, txDecoder sdk.TxDecoder) ([]sdk.Tx, []blockstm.MultiLocations) {
-	memTxs, estimates, _ := preEstimatesWithSigVerify(txs, workers, authStore, bankStore, evmDenom, txDecoder, nil)
-	return memTxs, estimates
 }
 
 // preEstimatesWithSigVerify returns a static estimation of the written keys for each transaction,

--- a/evmd/executor.go
+++ b/evmd/executor.go
@@ -83,7 +83,6 @@ func STMTxExecutor(
 		var memTxs []sdk.Tx
 		if estimate {
 			memTxs, estimates = preEstimateAndCacheSigResults(
-				ctx,
 				ms,
 				txs,
 				workers,
@@ -137,7 +136,6 @@ func initIncarnationCache(blockSize int) []atomic.Pointer[map[string]any] {
 }
 
 func preEstimateAndCacheSigResults(
-	ctx context.Context,
 	ms storetypes.MultiStore,
 	txs [][]byte,
 	workers, authStore, bankStore int,
@@ -146,13 +144,6 @@ func preEstimateAndCacheSigResults(
 	incarnationCache []atomic.Pointer[map[string]any],
 ) ([]sdk.Tx, []blockstm.MultiLocations) {
 	sdkCtx := sdk.NewContext(ms, cmtproto.Header{}, false, log.NewNopLogger())
-	func() {
-		defer func() {
-			_ = recover() // keep fallback sdkCtx if UnwrapSDKContext panics
-		}()
-		sdkCtx = sdk.UnwrapSDKContext(ctx)
-	}()
-
 	evmParams := evmKeeper.GetParams(sdkCtx)
 	evmDenom := evmParams.EvmDenom
 

--- a/evmd/executor_benchmark_test.go
+++ b/evmd/executor_benchmark_test.go
@@ -1,0 +1,248 @@
+package evmd
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"runtime"
+	"testing"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/store/metrics"
+	"cosmossdk.io/store/rootmulti"
+	storetypes "cosmossdk.io/store/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+
+	evmante "github.com/evmos/ethermint/ante"
+	"github.com/evmos/ethermint/crypto/ethsecp256k1"
+	"github.com/evmos/ethermint/evmd/ante"
+	testutilconfig "github.com/evmos/ethermint/testutil/config"
+	evmkeeper "github.com/evmos/ethermint/x/evm/keeper"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+)
+
+func BenchmarkPreEstimatesWithSigVerify(b *testing.B) {
+	b.StopTimer()
+
+	encCfg := testutilconfig.MakeConfigForTest(nil)
+	txConfig := encCfg.TxConfig
+	txDecoder := txConfig.TxDecoder()
+
+	chainID := big.NewInt(1)
+	signer := ethtypes.LatestSignerForChainID(chainID)
+
+	privKey, err := ethsecp256k1.GenerateKey()
+	if err != nil {
+		b.Fatal(err)
+	}
+	from := common.BytesToAddress(privKey.PubKey().Address())
+	keyringSigner := newBenchmarkSigner(privKey)
+
+	const txCount = 256
+	txs := make([][]byte, txCount)
+	for i := 0; i < txCount; i++ {
+		msg := evmtypes.NewTxContract(
+			chainID,
+			uint64(i),
+			big.NewInt(0),
+			params.TxGasContractCreation,
+			big.NewInt(1),
+			big.NewInt(1),
+			big.NewInt(1),
+			[]byte("contract_data"),
+			nil,
+		)
+		msg.From = from.Bytes()
+		err := msg.Sign(signer, keyringSigner)
+		if err != nil {
+			b.Fatal(err)
+		}
+		txBuilder := txConfig.NewTxBuilder()
+		if err := txBuilder.SetMsgs(msg); err != nil {
+			b.Fatal(err)
+		}
+		txBz, err := txConfig.TxEncoder()(txBuilder.GetTx())
+		if err != nil {
+			b.Fatal(err)
+		}
+		txs[i] = txBz
+	}
+
+	workers := runtime.GOMAXPROCS(0)
+	b.ReportAllocs()
+	b.StartTimer()
+
+	b.Run("baseline_no_sigverify", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			preEstimatesWithSigVerify(txs, workers, 0, 1, evmtypes.DefaultEVMDenom, txDecoder, nil)
+		}
+	})
+
+	b.Run("preverify_sig", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			preEstimatesWithSigVerify(txs, workers, 0, 1, evmtypes.DefaultEVMDenom, txDecoder, signer)
+		}
+	})
+}
+
+func BenchmarkSTMTxExecutorEndToEnd(b *testing.B) {
+	b.StopTimer()
+
+	encCfg := testutilconfig.MakeConfigForTest(nil)
+	txConfig := encCfg.TxConfig
+	txDecoder := txConfig.TxDecoder()
+
+	chainID := big.NewInt(1)
+	signer := ethtypes.LatestSignerForChainID(chainID)
+
+	privKey, err := ethsecp256k1.GenerateKey()
+	if err != nil {
+		b.Fatal(err)
+	}
+	from := common.BytesToAddress(privKey.PubKey().Address())
+	keyringSigner := newBenchmarkSigner(privKey)
+
+	const txCount = 256
+	txs := make([][]byte, txCount)
+	for i := 0; i < txCount; i++ {
+		msg := evmtypes.NewTxContract(
+			chainID,
+			uint64(i),
+			big.NewInt(0),
+			params.TxGasContractCreation,
+			big.NewInt(1),
+			big.NewInt(1),
+			big.NewInt(1),
+			[]byte("contract_data"),
+			nil,
+		)
+		msg.From = from.Bytes()
+		err := msg.Sign(signer, keyringSigner)
+		if err != nil {
+			b.Fatal(err)
+		}
+		txBuilder := txConfig.NewTxBuilder()
+		if err := txBuilder.SetMsgs(msg); err != nil {
+			b.Fatal(err)
+		}
+		txBz, err := txConfig.TxEncoder()(txBuilder.GetTx())
+		if err != nil {
+			b.Fatal(err)
+		}
+		txs[i] = txBz
+	}
+
+	authKey := storetypes.NewKVStoreKey("auth")
+	bankKey := storetypes.NewKVStoreKey("bank")
+	storeKeys := []storetypes.StoreKey{authKey, bankKey}
+
+	db := dbm.NewMemDB()
+	cms := rootmulti.NewStore(db, log.NewNopLogger(), metrics.NewNoOpMetrics())
+	for _, key := range storeKeys {
+		cms.MountStoreWithDB(key, storetypes.StoreTypeIAVL, nil)
+	}
+	if err := cms.LoadLatestVersion(); err != nil {
+		b.Fatal(err)
+	}
+
+	mockKeeper := benchmarkEvmKeeper{
+		params:  evmtypes.DefaultParams(),
+		chainID: chainID,
+	}
+	workers := runtime.GOMAXPROCS(0)
+
+	executor := STMTxExecutor(storeKeys, workers, true, mockKeeper, txDecoder)
+	deliver := func(_ int, tx sdk.Tx, _ storetypes.MultiStore, cache map[string]any) *abci.ExecTxResult {
+		if cache != nil {
+			if v, ok := cache[ante.EthSigVerificationResultCacheKey]; ok {
+				if err, ok := v.(error); ok && err != nil {
+					return &abci.ExecTxResult{Code: 1, Log: err.Error()}
+				}
+				return &abci.ExecTxResult{}
+			}
+		}
+		if err := evmante.VerifyEthSig(tx, signer); err != nil {
+			return &abci.ExecTxResult{Code: 1, Log: err.Error()}
+		}
+		return &abci.ExecTxResult{}
+	}
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := executor(context.Background(), txs, cms, deliver); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+type benchmarkSigner struct {
+	privKey cryptotypes.PrivKey
+}
+
+var _ keyring.Signer = benchmarkSigner{}
+
+func newBenchmarkSigner(sk cryptotypes.PrivKey) keyring.Signer {
+	return benchmarkSigner{privKey: sk}
+}
+
+func (s benchmarkSigner) Sign(_ string, msg []byte, _ signing.SignMode) ([]byte, cryptotypes.PubKey, error) {
+	if s.privKey.Type() != ethsecp256k1.KeyType {
+		return nil, nil, fmt.Errorf(
+			"invalid private key type for signing ethereum tx; expected %s, got %s",
+			ethsecp256k1.KeyType,
+			s.privKey.Type(),
+		)
+	}
+	sig, err := s.privKey.Sign(msg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sig, s.privKey.PubKey(), nil
+}
+
+func (s benchmarkSigner) SignByAddress(address sdk.Address, msg []byte, signMode signing.SignMode) ([]byte, cryptotypes.PubKey, error) {
+	signer := sdk.AccAddress(s.privKey.PubKey().Address())
+	if !signer.Equals(address) {
+		return nil, nil, fmt.Errorf("address mismatch: signer %s ≠ given address %s", signer, address)
+	}
+	return s.Sign("", msg, signMode)
+}
+
+type benchmarkEvmKeeper struct {
+	params  evmtypes.Params
+	chainID *big.Int
+}
+
+func (k benchmarkEvmKeeper) GetParams(_ sdk.Context) evmtypes.Params {
+	return k.params
+}
+
+func (k benchmarkEvmKeeper) ChainID() *big.Int {
+	return k.chainID
+}
+
+func (k benchmarkEvmKeeper) EVMBlockConfig(ctx sdk.Context, chainID *big.Int) (*evmkeeper.EVMBlockConfig, error) {
+	ethCfg := k.params.ChainConfig.EthereumConfig(chainID)
+	blockNumber := big.NewInt(ctx.BlockHeight())
+	var blockTime uint64
+	if !ctx.BlockHeader().Time.IsZero() {
+		blockTime = uint64(ctx.BlockHeader().Time.Unix())
+	}
+	rules := ethCfg.Rules(blockNumber, ethCfg.MergeNetsplitBlock != nil, blockTime)
+	return &evmkeeper.EVMBlockConfig{
+		Params:      k.params,
+		ChainConfig: ethCfg,
+		BlockNumber: blockNumber,
+		BlockTime:   blockTime,
+		Rules:       rules,
+	}, nil
+}

--- a/evmd/executor_benchmark_test.go
+++ b/evmd/executor_benchmark_test.go
@@ -94,6 +94,30 @@ func BenchmarkPreEstimatesWithSigVerify(b *testing.B) {
 }
 
 func BenchmarkSTMTxExecutorEndToEnd(b *testing.B) {
+	benchmarkSTMTxExecutor(b, 256, true, true)
+}
+
+func BenchmarkSTMTxExecutor_SmallBlock(b *testing.B) {
+	benchmarkSTMTxExecutor(b, 10, false, false)
+}
+
+func BenchmarkSTMTxExecutor_MediumBlock(b *testing.B) {
+	benchmarkSTMTxExecutor(b, 100, false, false)
+}
+
+func BenchmarkSTMTxExecutor_LargeBlock(b *testing.B) {
+	benchmarkSTMTxExecutor(b, 5000, false, false)
+}
+
+func BenchmarkSTMTxExecutor_WithEstimate(b *testing.B) {
+	benchmarkSTMTxExecutor(b, 256, true, false)
+}
+
+func BenchmarkSTMTxExecutor_MemoryAlloc(b *testing.B) {
+	benchmarkSTMTxExecutor(b, 256, true, true)
+}
+
+func benchmarkSTMTxExecutor(b *testing.B, txCount int, estimate bool, reportAllocs bool) {
 	b.StopTimer()
 
 	encCfg := testutilconfig.MakeConfigForTest(nil)
@@ -110,7 +134,6 @@ func BenchmarkSTMTxExecutorEndToEnd(b *testing.B) {
 	from := common.BytesToAddress(privKey.PubKey().Address())
 	keyringSigner := newBenchmarkSigner(privKey)
 
-	const txCount = 256
 	txs := make([][]byte, txCount)
 	for i := 0; i < txCount; i++ {
 		msg := evmtypes.NewTxContract(
@@ -159,8 +182,11 @@ func BenchmarkSTMTxExecutorEndToEnd(b *testing.B) {
 	}
 	workers := runtime.GOMAXPROCS(0)
 
-	executor := STMTxExecutor(storeKeys, workers, true, mockKeeper, txDecoder)
+	executor := STMTxExecutor(storeKeys, workers, estimate, mockKeeper, txDecoder)
 	deliver := func(_ int, tx sdk.Tx, _ storetypes.MultiStore, cache map[string]any) *abci.ExecTxResult {
+		if tx == nil {
+			return &abci.ExecTxResult{}
+		}
 		if cache != nil {
 			if v, ok := cache[ante.EthSigVerificationResultCacheKey]; ok {
 				if err, ok := v.(error); ok && err != nil {
@@ -175,7 +201,9 @@ func BenchmarkSTMTxExecutorEndToEnd(b *testing.B) {
 		return &abci.ExecTxResult{}
 	}
 
-	b.ReportAllocs()
+	if reportAllocs {
+		b.ReportAllocs()
+	}
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := executor(context.Background(), txs, cms, deliver); err != nil {


### PR DESCRIPTION
**Problem describe:**
The Ethereum signature verification (crypto.Ecrecover) happens inside the ante handler for each transaction sequentially during block execution, it is expensive to run it.
In Block-STM parallel execution, transactions may be re-executed multiple times (incarnations), causing redundant signature verifications
The signature verification cannot be parallelized in the ante handler since it runs per-transaction

**The Solution:**
Move signature verification to the pre-estimation phase where it already runs in parallel across worker goroutines, then cache the result so the ante handler can skip the redundant work.

**Benchmark:** (with Apple M1 Max)
Original - BenchmarkSTMTxExecutorEndToEnd-10    	     471	   2508649 ns/op	 3200984 B/op	   40586 allocs/op
After - BenchmarkSTMTxExecutorEndToEnd-10    	     661	   1776052 ns/op	 4490051 B/op	   45801 allocs/op

40% improved when block size is 256 txns running in the STMTxExecutor. 27.2% improved when block size is 5K txns.