### PR TITLE
fix(rpc): fix eth_getBlockReceipts crash 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* (rpc) [#870](https://github.com/crypto-org-chain/ethermint/pull/870) fix(rpc): fix eth_getBlockReceipts crash in block 6541
+* (rpc) [#870](https://github.com/crypto-org-chain/ethermint/pull/870) fix(rpc): fix eth_getBlockReceipts crash
 * (ante) [#829](https://github.com/crypto-org-chain/ethermint/pull/829) fix: validate payload messages in legacy EIP-712
 
 ## [v0.23.0] - 2026-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* (rpc) [#870](https://github.com/crypto-org-chain/ethermint/pull/870) fix(rpc): boundary check in GetTransactionReceipt + scope block receipts when KV tx-hash index is overwritten.
+* (rpc) [#870](https://github.com/crypto-org-chain/ethermint/pull/870) fix(rpc): fix eth_getBlockReceipts crash in block 6541
 * (ante) [#829](https://github.com/crypto-org-chain/ethermint/pull/829) fix: validate payload messages in legacy EIP-712
 
 ## [v0.23.0] - 2026-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+* (rpc) [#861](https://github.com/crypto-org-chain/ethermint/pull/861) fix(rpc): Missing boundary check in GetTransactionReceipt.
 * (ante) [#829](https://github.com/crypto-org-chain/ethermint/pull/829) fix: validate payload messages in legacy EIP-712
 
 ## [v0.23.0] - 2026-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* (rpc) [#861](https://github.com/crypto-org-chain/ethermint/pull/861) fix(rpc): Missing boundary check in GetTransactionReceipt.
+* (rpc) [#870](https://github.com/crypto-org-chain/ethermint/pull/870) fix(rpc): boundary check in GetTransactionReceipt + scope block receipts when KV tx-hash index is overwritten.
 * (ante) [#829](https://github.com/crypto-org-chain/ethermint/pull/829) fix: validate payload messages in legacy EIP-712
 
 ## [v0.23.0] - 2026-01-13

--- a/rpc/backend/backend.go
+++ b/rpc/backend/backend.go
@@ -122,7 +122,7 @@ type EVMBackend interface {
 	GetTxByEthHash(txHash common.Hash) (*ethermint.TxResult, error)
 	GetTxByTxIndex(height int64, txIndex uint) (*ethermint.TxResult, error)
 	GetTransactionByBlockAndIndex(block *tmrpctypes.ResultBlock, idx hexutil.Uint) (*rpctypes.RPCTransaction, error)
-	GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.ResultBlock) (map[string]interface{}, error)
+	GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.ResultBlock, blockRes *tmrpctypes.ResultBlockResults) (map[string]interface{}, error)
 	GetTransactionByBlockHashAndIndex(hash common.Hash, idx hexutil.Uint) (*rpctypes.RPCTransaction, error)
 	GetTransactionByBlockNumberAndIndex(blockNum rpctypes.BlockNumber, idx hexutil.Uint) (*rpctypes.RPCTransaction, error)
 	CreateAccessList(

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -115,6 +115,9 @@ func (b *Backend) GetBlockReceipts(blockNum rpctypes.BlockNumber) ([]map[string]
 		if err != nil {
 			return nil, err
 		}
+		if receipt == nil {
+			continue
+		}
 		res = append(res, receipt)
 	}
 

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -111,7 +111,7 @@ func (b *Backend) GetBlockReceipts(blockNum rpctypes.BlockNumber) ([]map[string]
 
 	res := make([]map[string]interface{}, 0, len(txHashes))
 	for _, txHash := range txHashes {
-		receipt, err := b.GetTransactionReceipt(txHash, resBlock)
+		receipt, err := b.GetTransactionReceipt(txHash, resBlock, blockRes)
 		if err != nil {
 			return nil, err
 		}

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -23,6 +23,7 @@ import (
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -30,7 +31,6 @@ import (
 	rpctypes "github.com/evmos/ethermint/rpc/types"
 	ethermint "github.com/evmos/ethermint/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
-	"github.com/pkg/errors"
 )
 
 // GetTransactionByHash returns the Ethereum format transaction identified by Ethereum transaction hash
@@ -48,15 +48,21 @@ func (b *Backend) GetTransactionByHash(txHash common.Hash) (*rpctypes.RPCTransac
 		return nil, err
 	}
 
+	if int(res.TxIndex) >= len(block.Block.Txs) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(block.Block.Txs))
+	}
 	tx, err := b.clientCtx.TxConfig.TxDecoder()(block.Block.Txs[res.TxIndex])
 	if err != nil {
 		return nil, err
 	}
 
-	// the `res.MsgIndex` is inferred from tx index, should be within the bound.
-	msg, ok := tx.GetMsgs()[res.MsgIndex].(*evmtypes.MsgEthereumTx)
+	msgs := tx.GetMsgs()
+	if int(res.MsgIndex) >= len(msgs) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
+	}
+	msg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
 	if !ok {
-		return nil, errors.New("invalid ethereum tx")
+		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
 	}
 
 	blockRes, err := b.TendermintBlockResultByNumber(&block.Block.Height)
@@ -81,7 +87,7 @@ func (b *Backend) GetTransactionByHash(txHash common.Hash) (*rpctypes.RPCTransac
 	}
 	// if we still unable to find the eth tx index, return error, shouldn't happen.
 	if res.EthTxIndex == -1 {
-		return nil, errors.New("can't find index of ethereum tx")
+		return nil, errorsmod.Wrap(errortypes.ErrNotFound, "can't find index of ethereum tx")
 	}
 	index, err := ethermint.SafeInt32ToUint64(res.EthTxIndex)
 	if err != nil {
@@ -166,17 +172,27 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.R
 			return nil, nil
 		}
 	}
+	if int(res.TxIndex) >= len(resBlock.Block.Txs) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(resBlock.Block.Txs))
+	}
 	tx, err := b.clientCtx.TxConfig.TxDecoder()(resBlock.Block.Txs[res.TxIndex])
 	if err != nil {
 		b.logger.Debug("decoding failed", "error", err.Error())
-		return nil, fmt.Errorf("failed to decode tx: %w", err)
+		return nil, errorsmod.Wrapf(errortypes.ErrTxDecode, "failed to decode tx: %v", err)
 	}
-	ethMsg := tx.GetMsgs()[res.MsgIndex].(*evmtypes.MsgEthereumTx)
+	msgs := tx.GetMsgs()
+	if int(res.MsgIndex) >= len(msgs) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
+	}
+	ethMsg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
+	if !ok {
+		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
+	}
 
 	txData := ethMsg.AsTransaction()
 	if txData == nil {
 		b.logger.Error("failed to unpack tx data")
-		return nil, err
+		return nil, errorsmod.Wrap(errortypes.ErrTxDecode, "failed to unpack tx data")
 	}
 
 	var cumulativeGasUsed uint64
@@ -184,6 +200,9 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.R
 	if err != nil {
 		b.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
 		return nil, nil
+	}
+	if int(res.TxIndex) >= len(blockRes.TxsResults) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", res.TxIndex, len(blockRes.TxsResults))
 	}
 	for _, txResult := range blockRes.TxsResults[0:res.TxIndex] {
 		gas, err := ethermint.SafeUint64(txResult.GasUsed)
@@ -241,7 +260,7 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.R
 	}
 	// return error if still unable to find the eth tx index
 	if res.EthTxIndex == -1 {
-		return nil, errors.New("can't find index of ethereum tx")
+		return nil, errorsmod.Wrap(errortypes.ErrNotFound, "can't find index of ethereum tx")
 	}
 
 	blockNumber, err := ethermint.SafeUint64(res.Height)
@@ -315,7 +334,7 @@ func (b *Backend) GetTransactionByBlockHashAndIndex(hash common.Hash, idx hexuti
 
 	sc, ok := b.clientCtx.Client.(tmrpcclient.SignClient)
 	if !ok {
-		return nil, errors.New("invalid rpc client")
+		return nil, errorsmod.Wrap(errortypes.ErrInvalidType, "invalid rpc client")
 	}
 
 	block, err := sc.BlockByHash(b.ctx, hash.Bytes())
@@ -401,14 +420,14 @@ func (b *Backend) GetTxByTxIndex(height int64, i uint) (*ethermint.TxResult, err
 func (b *Backend) queryTendermintTxIndexer(query string, txGetter func(*rpctypes.ParsedTxs) *rpctypes.ParsedTx) (*ethermint.TxResult, error) {
 	resTxs, err := b.clientCtx.Client.TxSearch(b.ctx, query, false, nil, nil, "")
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrapf(err, "failed to search tx in tendermint indexer, query: %s", query)
 	}
 	if len(resTxs.Txs) == 0 {
-		return nil, errors.New("ethereum tx not found")
+		return nil, errorsmod.Wrap(errortypes.ErrNotFound, "ethereum tx not found")
 	}
 	txResult := resTxs.Txs[0]
 	if !rpctypes.TxSuccessOrExceedsBlockGasLimit(&txResult.TxResult) {
-		return nil, errors.New("invalid ethereum tx")
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "ethereum tx failed, code: %d, log: %s", txResult.TxResult.Code, txResult.TxResult.Log)
 	}
 
 	var tx sdk.Tx
@@ -416,7 +435,7 @@ func (b *Backend) queryTendermintTxIndexer(query string, txGetter func(*rpctypes
 		// it's only needed when the tx exceeds block gas limit
 		tx, err = b.clientCtx.TxConfig.TxDecoder()(txResult.Tx)
 		if err != nil {
-			return nil, fmt.Errorf("invalid ethereum tx")
+			return nil, errorsmod.Wrapf(errortypes.ErrTxDecode, "failed to decode tx: %v", err)
 		}
 	}
 
@@ -434,15 +453,21 @@ func (b *Backend) GetTransactionByBlockAndIndex(block *tmrpctypes.ResultBlock, i
 	// find in tx indexer
 	res, err := b.GetTxByTxIndex(block.Block.Height, uint(idx))
 	if err == nil {
+		if int(res.TxIndex) >= len(block.Block.Txs) {
+			return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(block.Block.Txs))
+		}
 		tx, err := b.clientCtx.TxConfig.TxDecoder()(block.Block.Txs[res.TxIndex])
 		if err != nil {
 			b.logger.Debug("invalid ethereum tx", "height", block.Block.Header, "index", idx)
 			return nil, nil
 		}
 
+		msgs := tx.GetMsgs()
+		if int(res.MsgIndex) >= len(msgs) {
+			return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
+		}
 		var ok bool
-		// msgIndex is inferred from tx events, should be within bound.
-		msg, ok = tx.GetMsgs()[res.MsgIndex].(*evmtypes.MsgEthereumTx)
+		msg, ok = msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
 		if !ok {
 			b.logger.Debug("invalid ethereum tx", "height", block.Block.Header, "index", idx)
 			return nil, nil

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -287,9 +287,10 @@ func (b *Backend) prepareTransactionReceipt(
 		}
 		// Use indexer only when it points to this block.
 		indexed, errIdx := b.GetTxByEthHash(hash)
-		if errIdx == nil && indexed.Height == resBlock.Block.Height {
+		switch {
+		case errIdx == nil && indexed.Height == resBlock.Block.Height:
 			res = indexed
-		} else if errIdx != nil {
+		case errIdx != nil:
 			// Hash not in index → rebuild from block data.
 			res, err = b.txResultFromBlockHash(resBlock, blockRes, hash)
 			if err != nil {
@@ -298,7 +299,7 @@ func (b *Backend) prepareTransactionReceipt(
 			if res == nil {
 				return nil, nil, nil, nil
 			}
-		} else {
+		default:
 			// Index points to another height → skip for this block.
 			return nil, nil, nil, nil
 		}

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -22,6 +22,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	tmtypes "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/common"
@@ -48,21 +49,9 @@ func (b *Backend) GetTransactionByHash(txHash common.Hash) (*rpctypes.RPCTransac
 		return nil, err
 	}
 
-	if int(res.TxIndex) >= len(block.Block.Txs) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(block.Block.Txs))
-	}
-	tx, err := b.clientCtx.TxConfig.TxDecoder()(block.Block.Txs[res.TxIndex])
+	msg, err := b.ethMsgAtTxResult(block.Block, res)
 	if err != nil {
 		return nil, err
-	}
-
-	msgs := tx.GetMsgs()
-	if int(res.MsgIndex) >= len(msgs) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
-	}
-	msg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
-	if !ok {
-		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
 	}
 
 	blockRes, err := b.TendermintBlockResultByNumber(&block.Block.Height)
@@ -156,6 +145,37 @@ func (b *Backend) GetGasUsed(res *ethermint.TxResult, gas uint64) uint64 {
 	return res.GasUsed
 }
 
+// ethMsgAtTxResult returns the MsgEthereumTx for an indexed inclusion in block.Txs.
+func (b *Backend) ethMsgAtTxResult(
+	block *tmtypes.Block, res *ethermint.TxResult,
+) (*evmtypes.MsgEthereumTx, error) {
+	if int(res.TxIndex) >= len(block.Txs) {
+		return nil, errorsmod.Wrapf(
+			errortypes.ErrLogic,
+			"tx index %d out of range (block has %d txs)", res.TxIndex, len(block.Txs),
+		)
+	}
+	tx, err := b.clientCtx.TxConfig.TxDecoder()(block.Txs[res.TxIndex])
+	if err != nil {
+		return nil, errorsmod.Wrapf(errortypes.ErrTxDecode, "failed to decode tx: %v", err)
+	}
+	msgs := tx.GetMsgs()
+	if int(res.MsgIndex) >= len(msgs) {
+		return nil, errorsmod.Wrapf(
+			errortypes.ErrLogic,
+			"msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs),
+		)
+	}
+	msg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
+	if !ok {
+		return nil, errorsmod.Wrapf(
+			errortypes.ErrInvalidType,
+			"msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex],
+		)
+	}
+	return msg, nil
+}
+
 // txResultFromBlockHash reconstructs ethermint.TxResult for an Ethereum tx hash from the given block only.
 // It must be used when serving receipts for a specific block (e.g. eth_getBlockReceipts): the KV tx-hash index
 // stores at most one inclusion per hash, so a later block can overwrite an earlier failed inclusion.
@@ -169,6 +189,11 @@ func (b *Backend) txResultFromBlockHash(
 
 	var ethTxIndex int32
 	for txIndex := range block.Txs {
+		if txIndex >= len(txResults) {
+			b.logger.Debug("block.Txs/blockRes.TxsResults length mismatch",
+				"height", block.Height, "txs", len(block.Txs), "txResults", len(txResults))
+			break
+		}
 		if !rpctypes.TxSuccessOrExceedsBlockGasLimit(txResults[txIndex]) {
 			continue
 		}
@@ -242,13 +267,12 @@ func (b *Backend) txResultFromBlockHash(
 	return nil, nil
 }
 
-// GetTransactionReceipt returns the transaction receipt identified by hash.
-// It takes optional resBlock and blockRes; if nil the method will fetch them.
-func (b *Backend) GetTransactionReceipt(
-	hash common.Hash, resBlock *tmrpctypes.ResultBlock, blockRes *tmrpctypes.ResultBlockResults,
-) (map[string]interface{}, error) {
-	b.logger.Debug("eth_getTransactionReceipt", "hash", hash)
-
+// prepareTransactionReceipt resolves the TxResult, block, and block results for a tx hash.
+func (b *Backend) prepareTransactionReceipt(
+	hash common.Hash,
+	resBlock *tmrpctypes.ResultBlock,
+	blockRes *tmrpctypes.ResultBlockResults,
+) (*ethermint.TxResult, *tmrpctypes.ResultBlock, *tmrpctypes.ResultBlockResults, error) {
 	var res *ethermint.TxResult
 	var err error
 
@@ -256,57 +280,57 @@ func (b *Backend) GetTransactionReceipt(
 		if blockRes == nil {
 			blockRes, err = b.TendermintBlockResultByNumber(&resBlock.Block.Height)
 			if err != nil {
-				b.logger.Debug("failed to retrieve block results", "height", resBlock.Block.Height, "error", err.Error())
-				return nil, nil
+				b.logger.Debug("failed to retrieve block results",
+					"height", resBlock.Block.Height, "error", err.Error())
+				return nil, nil, nil, nil
 			}
 		}
 		// Prefer the tx indexer when it refers to this exact block. If the same eth tx hash was
-		// included again in a later block, the KV index only keeps the latest inclusion; rebuild from
-		// the block when heights disagree or the hash is missing from the index.
+		// included again in a later block, the KV index only keeps the latest inclusion; rebuild
+		// from the block when heights disagree or the hash is missing from the index.
 		indexed, errIdx := b.GetTxByEthHash(hash)
 		if errIdx == nil && indexed.Height == resBlock.Block.Height {
 			res = indexed
 		} else {
 			res, err = b.txResultFromBlockHash(resBlock, blockRes, hash)
 			if err != nil {
-				return nil, err
+				return nil, nil, nil, err
 			}
 			if res == nil {
-				return nil, nil
+				return nil, nil, nil, nil
 			}
 		}
 	} else {
 		res, err = b.GetTxByEthHash(hash)
 		if err != nil {
 			b.logger.Debug("tx not found", "hash", hash, "error", err.Error())
-			return nil, nil
+			return nil, nil, nil, nil
 		}
 		resBlock, err = b.TendermintBlockByNumber(rpctypes.BlockNumber(res.Height))
 		if err != nil {
 			b.logger.Debug("block not found", "height", res.Height, "error", err.Error())
-			return nil, nil
+			return nil, nil, nil, nil
 		}
 		blockRes, err = b.TendermintBlockResultByNumber(&res.Height)
 		if err != nil {
-			b.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
-			return nil, nil
+			b.logger.Debug("failed to retrieve block results",
+				"height", res.Height, "error", err.Error())
+			return nil, nil, nil, nil
 		}
 	}
-	if int(res.TxIndex) >= len(resBlock.Block.Txs) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(resBlock.Block.Txs))
-	}
-	tx, err := b.clientCtx.TxConfig.TxDecoder()(resBlock.Block.Txs[res.TxIndex])
+	return res, resBlock, blockRes, nil
+}
+
+// transactionReceiptToJSON converts a resolved tx result into an Ethereum-compatible receipt map.
+func (b *Backend) transactionReceiptToJSON(
+	hash common.Hash,
+	res *ethermint.TxResult,
+	resBlock *tmrpctypes.ResultBlock,
+	blockRes *tmrpctypes.ResultBlockResults,
+) (map[string]interface{}, error) {
+	ethMsg, err := b.ethMsgAtTxResult(resBlock.Block, res)
 	if err != nil {
-		b.logger.Debug("decoding failed", "error", err.Error())
-		return nil, errorsmod.Wrapf(errortypes.ErrTxDecode, "failed to decode tx: %v", err)
-	}
-	msgs := tx.GetMsgs()
-	if int(res.MsgIndex) >= len(msgs) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
-	}
-	ethMsg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
-	if !ok {
-		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
+		return nil, err
 	}
 
 	txData := ethMsg.AsTransaction()
@@ -317,7 +341,11 @@ func (b *Backend) GetTransactionReceipt(
 
 	var cumulativeGasUsed uint64
 	if int(res.TxIndex) >= len(blockRes.TxsResults) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", res.TxIndex, len(blockRes.TxsResults))
+		return nil, errorsmod.Wrapf(
+			errortypes.ErrLogic,
+			"tx index %d out of range for block results (%d txs)",
+			res.TxIndex, len(blockRes.TxsResults),
+		)
 	}
 	for _, txResult := range blockRes.TxsResults[0:res.TxIndex] {
 		gas, err := ethermint.SafeUint64(txResult.GasUsed)
@@ -434,13 +462,31 @@ func (b *Backend) GetTransactionReceipt(
 		baseFee, err := b.BaseFee(blockRes)
 		if err != nil {
 			// tolerate the error for pruned node.
-			b.logger.Error("fetch basefee failed, node is pruned?", "height", res.Height, "error", err)
+			b.logger.Error("fetch basefee failed, node is pruned?",
+				"height", res.Height, "error", err)
 		} else {
 			receipt["effectiveGasPrice"] = hexutil.Big(*ethMsg.GetEffectiveGasPrice(baseFee))
 		}
 	}
 
 	return receipt, nil
+}
+
+// GetTransactionReceipt returns the transaction receipt identified by hash.
+// It takes optional resBlock and blockRes; if nil the method will fetch them.
+func (b *Backend) GetTransactionReceipt(
+	hash common.Hash, resBlock *tmrpctypes.ResultBlock, blockRes *tmrpctypes.ResultBlockResults,
+) (map[string]interface{}, error) {
+	b.logger.Debug("eth_getTransactionReceipt", "hash", hash)
+
+	res, resBlock, blockRes, err := b.prepareTransactionReceipt(hash, resBlock, blockRes)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, nil
+	}
+	return b.transactionReceiptToJSON(hash, res, resBlock, blockRes)
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction identified by hash and index.
@@ -568,24 +614,9 @@ func (b *Backend) GetTransactionByBlockAndIndex(block *tmrpctypes.ResultBlock, i
 	// find in tx indexer
 	res, err := b.GetTxByTxIndex(block.Block.Height, uint(idx))
 	if err == nil {
-		if int(res.TxIndex) >= len(block.Block.Txs) {
-			return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(block.Block.Txs))
-		}
-		tx, err := b.clientCtx.TxConfig.TxDecoder()(block.Block.Txs[res.TxIndex])
+		msg, err = b.ethMsgAtTxResult(block.Block, res)
 		if err != nil {
-			b.logger.Debug("invalid ethereum tx", "height", block.Block.Header, "index", idx)
-			return nil, nil
-		}
-
-		msgs := tx.GetMsgs()
-		if int(res.MsgIndex) >= len(msgs) {
-			return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
-		}
-		var ok bool
-		msg, ok = msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
-		if !ok {
-			b.logger.Debug("invalid ethereum tx", "height", block.Block.Header, "index", idx)
-			return nil, nil
+			return nil, err
 		}
 	} else {
 		i, err := ethermint.SafeHexToInt(idx)

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -22,7 +22,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
-	tmtypes "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/common"
@@ -49,9 +48,21 @@ func (b *Backend) GetTransactionByHash(txHash common.Hash) (*rpctypes.RPCTransac
 		return nil, err
 	}
 
-	msg, err := b.ethMsgAtTxResult(block.Block, res)
+	if int(res.TxIndex) >= len(block.Block.Txs) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(block.Block.Txs))
+	}
+	tx, err := b.clientCtx.TxConfig.TxDecoder()(block.Block.Txs[res.TxIndex])
 	if err != nil {
 		return nil, err
+	}
+
+	msgs := tx.GetMsgs()
+	if int(res.MsgIndex) >= len(msgs) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
+	}
+	msg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
+	if !ok {
+		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
 	}
 
 	blockRes, err := b.TendermintBlockResultByNumber(&block.Block.Height)
@@ -145,37 +156,6 @@ func (b *Backend) GetGasUsed(res *ethermint.TxResult, gas uint64) uint64 {
 	return res.GasUsed
 }
 
-// ethMsgAtTxResult returns the MsgEthereumTx for an indexed inclusion in block.Txs.
-func (b *Backend) ethMsgAtTxResult(
-	block *tmtypes.Block, res *ethermint.TxResult,
-) (*evmtypes.MsgEthereumTx, error) {
-	if int(res.TxIndex) >= len(block.Txs) {
-		return nil, errorsmod.Wrapf(
-			errortypes.ErrLogic,
-			"tx index %d out of range (block has %d txs)", res.TxIndex, len(block.Txs),
-		)
-	}
-	tx, err := b.clientCtx.TxConfig.TxDecoder()(block.Txs[res.TxIndex])
-	if err != nil {
-		return nil, errorsmod.Wrapf(errortypes.ErrTxDecode, "failed to decode tx: %v", err)
-	}
-	msgs := tx.GetMsgs()
-	if int(res.MsgIndex) >= len(msgs) {
-		return nil, errorsmod.Wrapf(
-			errortypes.ErrLogic,
-			"msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs),
-		)
-	}
-	msg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
-	if !ok {
-		return nil, errorsmod.Wrapf(
-			errortypes.ErrInvalidType,
-			"msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex],
-		)
-	}
-	return msg, nil
-}
-
 // txResultFromBlockHash reconstructs ethermint.TxResult for an Ethereum tx hash from the given block only.
 // It must be used when serving receipts for a specific block (e.g. eth_getBlockReceipts): the KV tx-hash index
 // stores at most one inclusion per hash, so a later block can overwrite an earlier failed inclusion.
@@ -267,12 +247,13 @@ func (b *Backend) txResultFromBlockHash(
 	return nil, nil
 }
 
-// prepareTransactionReceipt resolves the TxResult, block, and block results for a tx hash.
-func (b *Backend) prepareTransactionReceipt(
-	hash common.Hash,
-	resBlock *tmrpctypes.ResultBlock,
-	blockRes *tmrpctypes.ResultBlockResults,
-) (*ethermint.TxResult, *tmrpctypes.ResultBlock, *tmrpctypes.ResultBlockResults, error) {
+// GetTransactionReceipt returns the transaction receipt identified by hash.
+// It takes optional resBlock and blockRes; if nil the method will fetch them.
+func (b *Backend) GetTransactionReceipt(
+	hash common.Hash, resBlock *tmrpctypes.ResultBlock, blockRes *tmrpctypes.ResultBlockResults,
+) (map[string]interface{}, error) {
+	b.logger.Debug("eth_getTransactionReceipt", "hash", hash)
+
 	var res *ethermint.TxResult
 	var err error
 
@@ -280,9 +261,8 @@ func (b *Backend) prepareTransactionReceipt(
 		if blockRes == nil {
 			blockRes, err = b.TendermintBlockResultByNumber(&resBlock.Block.Height)
 			if err != nil {
-				b.logger.Debug("failed to retrieve block results",
-					"height", resBlock.Block.Height, "error", err.Error())
-				return nil, nil, nil, nil
+				b.logger.Debug("failed to retrieve block results", "height", resBlock.Block.Height, "error", err.Error())
+				return nil, nil
 			}
 		}
 		// Use indexer only when it points to this block.
@@ -294,46 +274,47 @@ func (b *Backend) prepareTransactionReceipt(
 			// Hash not in index → rebuild from block data.
 			res, err = b.txResultFromBlockHash(resBlock, blockRes, hash)
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, err
 			}
 			if res == nil {
-				return nil, nil, nil, nil
+				return nil, nil
 			}
 		default:
 			// Index points to another height → skip for this block.
-			return nil, nil, nil, nil
+			return nil, nil
 		}
 	} else {
 		res, err = b.GetTxByEthHash(hash)
 		if err != nil {
 			b.logger.Debug("tx not found", "hash", hash, "error", err.Error())
-			return nil, nil, nil, nil
+			return nil, nil
 		}
 		resBlock, err = b.TendermintBlockByNumber(rpctypes.BlockNumber(res.Height))
 		if err != nil {
 			b.logger.Debug("block not found", "height", res.Height, "error", err.Error())
-			return nil, nil, nil, nil
+			return nil, nil
 		}
 		blockRes, err = b.TendermintBlockResultByNumber(&res.Height)
 		if err != nil {
-			b.logger.Debug("failed to retrieve block results",
-				"height", res.Height, "error", err.Error())
-			return nil, nil, nil, nil
+			b.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
+			return nil, nil
 		}
 	}
-	return res, resBlock, blockRes, nil
-}
-
-// transactionReceiptToJSON converts a resolved tx result into an Ethereum-compatible receipt map.
-func (b *Backend) transactionReceiptToJSON(
-	hash common.Hash,
-	res *ethermint.TxResult,
-	resBlock *tmrpctypes.ResultBlock,
-	blockRes *tmrpctypes.ResultBlockResults,
-) (map[string]interface{}, error) {
-	ethMsg, err := b.ethMsgAtTxResult(resBlock.Block, res)
+	if int(res.TxIndex) >= len(resBlock.Block.Txs) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(resBlock.Block.Txs))
+	}
+	tx, err := b.clientCtx.TxConfig.TxDecoder()(resBlock.Block.Txs[res.TxIndex])
 	if err != nil {
-		return nil, err
+		b.logger.Debug("decoding failed", "error", err.Error())
+		return nil, errorsmod.Wrapf(errortypes.ErrTxDecode, "failed to decode tx: %v", err)
+	}
+	msgs := tx.GetMsgs()
+	if int(res.MsgIndex) >= len(msgs) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
+	}
+	ethMsg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
+	if !ok {
+		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
 	}
 
 	txData := ethMsg.AsTransaction()
@@ -344,11 +325,7 @@ func (b *Backend) transactionReceiptToJSON(
 
 	var cumulativeGasUsed uint64
 	if int(res.TxIndex) >= len(blockRes.TxsResults) {
-		return nil, errorsmod.Wrapf(
-			errortypes.ErrLogic,
-			"tx index %d out of range for block results (%d txs)",
-			res.TxIndex, len(blockRes.TxsResults),
-		)
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", res.TxIndex, len(blockRes.TxsResults))
 	}
 	for _, txResult := range blockRes.TxsResults[0:res.TxIndex] {
 		gas, err := ethermint.SafeUint64(txResult.GasUsed)
@@ -465,31 +442,13 @@ func (b *Backend) transactionReceiptToJSON(
 		baseFee, err := b.BaseFee(blockRes)
 		if err != nil {
 			// tolerate the error for pruned node.
-			b.logger.Error("fetch basefee failed, node is pruned?",
-				"height", res.Height, "error", err)
+			b.logger.Error("fetch basefee failed, node is pruned?", "height", res.Height, "error", err)
 		} else {
 			receipt["effectiveGasPrice"] = hexutil.Big(*ethMsg.GetEffectiveGasPrice(baseFee))
 		}
 	}
 
 	return receipt, nil
-}
-
-// GetTransactionReceipt returns the transaction receipt identified by hash.
-// It takes optional resBlock and blockRes; if nil the method will fetch them.
-func (b *Backend) GetTransactionReceipt(
-	hash common.Hash, resBlock *tmrpctypes.ResultBlock, blockRes *tmrpctypes.ResultBlockResults,
-) (map[string]interface{}, error) {
-	b.logger.Debug("eth_getTransactionReceipt", "hash", hash)
-
-	res, resBlock, blockRes, err := b.prepareTransactionReceipt(hash, resBlock, blockRes)
-	if err != nil {
-		return nil, err
-	}
-	if res == nil {
-		return nil, nil
-	}
-	return b.transactionReceiptToJSON(hash, res, resBlock, blockRes)
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction identified by hash and index.
@@ -617,9 +576,24 @@ func (b *Backend) GetTransactionByBlockAndIndex(block *tmrpctypes.ResultBlock, i
 	// find in tx indexer
 	res, err := b.GetTxByTxIndex(block.Block.Height, uint(idx))
 	if err == nil {
-		msg, err = b.ethMsgAtTxResult(block.Block, res)
+		if int(res.TxIndex) >= len(block.Block.Txs) {
+			return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(block.Block.Txs))
+		}
+		tx, err := b.clientCtx.TxConfig.TxDecoder()(block.Block.Txs[res.TxIndex])
 		if err != nil {
-			return nil, err
+			b.logger.Debug("invalid ethereum tx", "height", block.Block.Header, "index", idx)
+			return nil, nil
+		}
+
+		msgs := tx.GetMsgs()
+		if int(res.MsgIndex) >= len(msgs) {
+			return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
+		}
+		var ok bool
+		msg, ok = msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
+		if !ok {
+			b.logger.Debug("invalid ethereum tx", "height", block.Block.Header, "index", idx)
+			return nil, nil
 		}
 	} else {
 		i, err := ethermint.SafeHexToInt(idx)

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -242,19 +242,21 @@ func (b *Backend) txResultFromBlockHash(
 	return nil, nil
 }
 
-// GetTransactionReceipt returns the transaction receipt identified by hash. It takes an optional resBlock, if nil then the method will fetch it.
-func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.ResultBlock) (map[string]interface{}, error) {
+// GetTransactionReceipt returns the transaction receipt identified by hash.
+// It takes optional resBlock and blockRes; if nil the method will fetch them.
+func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.ResultBlock, blockRes *tmrpctypes.ResultBlockResults) (map[string]interface{}, error) {
 	b.logger.Debug("eth_getTransactionReceipt", "hash", hash)
 
 	var res *ethermint.TxResult
-	var blockRes *tmrpctypes.ResultBlockResults
 	var err error
 
 	if resBlock != nil {
-		blockRes, err = b.TendermintBlockResultByNumber(&resBlock.Block.Height)
-		if err != nil {
-			b.logger.Debug("failed to retrieve block results", "height", resBlock.Block.Height, "error", err.Error())
-			return nil, nil
+		if blockRes == nil {
+			blockRes, err = b.TendermintBlockResultByNumber(&resBlock.Block.Height)
+			if err != nil {
+				b.logger.Debug("failed to retrieve block results", "height", resBlock.Block.Height, "error", err.Error())
+				return nil, nil
+			}
 		}
 		// Prefer the tx indexer when it refers to this exact block. If the same eth tx hash was
 		// included again in a later block, the KV index only keeps the latest inclusion; rebuild from

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -156,97 +156,6 @@ func (b *Backend) GetGasUsed(res *ethermint.TxResult, gas uint64) uint64 {
 	return res.GasUsed
 }
 
-// txResultFromBlockHash reconstructs ethermint.TxResult for an Ethereum tx hash from the given block only.
-// It must be used when serving receipts for a specific block (e.g. eth_getBlockReceipts): the KV tx-hash index
-// stores at most one inclusion per hash, so a later block can overwrite an earlier failed inclusion.
-func (b *Backend) txResultFromBlockHash(
-	resBlock *tmrpctypes.ResultBlock,
-	blockRes *tmrpctypes.ResultBlockResults,
-	hash common.Hash,
-) (*ethermint.TxResult, error) {
-	block := resBlock.Block
-	txResults := blockRes.TxsResults
-
-	var ethTxIndex int32
-	for txIndex := range block.Txs {
-		if txIndex >= len(txResults) {
-			b.logger.Debug("block.Txs/blockRes.TxsResults length mismatch",
-				"height", block.Height, "txs", len(block.Txs), "txResults", len(txResults))
-			break
-		}
-		if !rpctypes.TxSuccessOrExceedsBlockGasLimit(txResults[txIndex]) {
-			continue
-		}
-
-		sdkTx, err := b.clientCtx.TxConfig.TxDecoder()(block.Txs[txIndex])
-		if err != nil {
-			b.logger.Debug("failed to decode transaction in block", "height", block.Height, "error", err.Error())
-			continue
-		}
-
-		txsParsed, err := rpctypes.ParseTxResult(txResults[txIndex], sdkTx)
-		if err != nil {
-			return nil, errorsmod.Wrapf(err, "failed to parse tx events at height %d txIndex %d", block.Height, txIndex)
-		}
-
-		txIdx, err := ethermint.SafeUint32(txIndex)
-		if err != nil {
-			return nil, err
-		}
-
-		var cumulativeGasUsed uint64
-		for msgIndex, msg := range sdkTx.GetMsgs() {
-			ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
-			if !ok {
-				continue
-			}
-			if ethMsg.Hash() != hash {
-				var gasUsed uint64
-				if txResults[txIndex].Code != 0 {
-					gasUsed = ethMsg.GetGas()
-				} else {
-					parsedTx := txsParsed.GetTxByMsgIndex(msgIndex)
-					if parsedTx == nil {
-						return nil, errorsmod.Wrapf(errortypes.ErrLogic, "parsed tx nil for msgIndex %d", msgIndex)
-					}
-					gasUsed = parsedTx.GasUsed
-				}
-				cumulativeGasUsed += gasUsed
-				ethTxIndex++
-				continue
-			}
-
-			msgIdx, err := ethermint.SafeUint32(msgIndex)
-			if err != nil {
-				return nil, err
-			}
-
-			res := &ethermint.TxResult{
-				Height:     block.Height,
-				TxIndex:    txIdx,
-				MsgIndex:   msgIdx,
-				EthTxIndex: ethTxIndex,
-			}
-			if txResults[txIndex].Code != 0 {
-				res.GasUsed = ethMsg.GetGas()
-				res.Failed = true
-			} else {
-				parsedTx := txsParsed.GetTxByMsgIndex(msgIndex)
-				if parsedTx == nil {
-					return nil, errorsmod.Wrapf(errortypes.ErrLogic, "parsed tx nil for msgIndex %d", msgIndex)
-				}
-				res.GasUsed = parsedTx.GasUsed
-				res.Failed = parsedTx.Failed
-			}
-			cumulativeGasUsed += res.GasUsed
-			res.CumulativeGasUsed = cumulativeGasUsed
-			return res, nil
-		}
-	}
-
-	return nil, nil
-}
-
 // GetTransactionReceipt returns the transaction receipt identified by hash.
 // It takes optional resBlock and blockRes; if nil the method will fetch them.
 func (b *Backend) GetTransactionReceipt(
@@ -267,19 +176,10 @@ func (b *Backend) GetTransactionReceipt(
 		}
 		// Use indexer only when it points to this block.
 		indexed, errIdx := b.GetTxByEthHash(hash)
-		switch {
-		case errIdx == nil && indexed.Height == resBlock.Block.Height:
+		if errIdx == nil && indexed.Height == resBlock.Block.Height {
 			res = indexed
-		case errIdx != nil:
-			// Hash not in index → rebuild from block data.
-			res, err = b.txResultFromBlockHash(resBlock, blockRes, hash)
-			if err != nil {
-				return nil, err
-			}
-			if res == nil {
-				return nil, nil
-			}
-		default:
+		} else {
+			// Hash not in index or
 			// Index points to another height → skip for this block.
 			return nil, nil
 		}

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -285,13 +285,12 @@ func (b *Backend) prepareTransactionReceipt(
 				return nil, nil, nil, nil
 			}
 		}
-		// Prefer the tx indexer when it refers to this exact block. If the same eth tx hash was
-		// included again in a later block, the KV index only keeps the latest inclusion; rebuild
-		// from the block when heights disagree or the hash is missing from the index.
+		// Use indexer only when it points to this block.
 		indexed, errIdx := b.GetTxByEthHash(hash)
 		if errIdx == nil && indexed.Height == resBlock.Block.Height {
 			res = indexed
-		} else {
+		} else if errIdx != nil {
+			// Hash not in index → rebuild from block data.
 			res, err = b.txResultFromBlockHash(resBlock, blockRes, hash)
 			if err != nil {
 				return nil, nil, nil, err
@@ -299,6 +298,9 @@ func (b *Backend) prepareTransactionReceipt(
 			if res == nil {
 				return nil, nil, nil, nil
 			}
+		} else {
+			// Index points to another height → skip for this block.
+			return nil, nil, nil, nil
 		}
 	} else {
 		res, err = b.GetTxByEthHash(hash)

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -176,13 +176,11 @@ func (b *Backend) GetTransactionReceipt(
 		}
 		// Use indexer only when it points to this block.
 		indexed, errIdx := b.GetTxByEthHash(hash)
-		if errIdx == nil && indexed.Height == resBlock.Block.Height {
-			res = indexed
-		} else {
-			// Hash not in index or
-			// Index points to another height → skip for this block.
+		if errIdx != nil || indexed.Height != resBlock.Block.Height {
+			// Hash not in index or index points to another height → skip for this block.
 			return nil, nil
 		}
+		res = indexed
 	} else {
 		res, err = b.GetTxByEthHash(hash)
 		if err != nil {
@@ -266,6 +264,9 @@ func (b *Backend) GetTransactionReceipt(
 	if err != nil {
 		b.logger.Debug("failed to parse logs", "hash", hash, "error", err.Error())
 	}
+	if logs == nil {
+		logs = []*ethtypes.Log{}
+	}
 
 	if res.EthTxIndex == -1 {
 		// Fallback to find tx index by iterating all valid eth transactions
@@ -326,11 +327,7 @@ func (b *Backend) GetTransactionReceipt(
 		// sender and receiver (contract or EOA) addreses
 		"from": from,
 		"to":   txData.To(),
-		"type": hexutil.Uint(ethMsg.AsTransaction().Type()),
-	}
-
-	if logs == nil {
-		receipt["logs"] = [][]*ethtypes.Log{}
+		"type": hexutil.Uint(txData.Type()),
 	}
 
 	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -156,19 +156,135 @@ func (b *Backend) GetGasUsed(res *ethermint.TxResult, gas uint64) uint64 {
 	return res.GasUsed
 }
 
+// txResultFromBlockHash reconstructs ethermint.TxResult for an Ethereum tx hash from the given block only.
+// It must be used when serving receipts for a specific block (e.g. eth_getBlockReceipts): the KV tx-hash index
+// stores at most one inclusion per hash, so a later block can overwrite an earlier failed inclusion.
+func (b *Backend) txResultFromBlockHash(
+	resBlock *tmrpctypes.ResultBlock,
+	blockRes *tmrpctypes.ResultBlockResults,
+	hash common.Hash,
+) (*ethermint.TxResult, error) {
+	block := resBlock.Block
+	txResults := blockRes.TxsResults
+
+	var ethTxIndex int32
+	for txIndex := range block.Txs {
+		if !rpctypes.TxSuccessOrExceedsBlockGasLimit(txResults[txIndex]) {
+			continue
+		}
+
+		sdkTx, err := b.clientCtx.TxConfig.TxDecoder()(block.Txs[txIndex])
+		if err != nil {
+			b.logger.Debug("failed to decode transaction in block", "height", block.Height, "error", err.Error())
+			continue
+		}
+
+		txsParsed, err := rpctypes.ParseTxResult(txResults[txIndex], sdkTx)
+		if err != nil {
+			return nil, errorsmod.Wrapf(err, "failed to parse tx events at height %d txIndex %d", block.Height, txIndex)
+		}
+
+		txIdx, err := ethermint.SafeUint32(txIndex)
+		if err != nil {
+			return nil, err
+		}
+
+		var cumulativeGasUsed uint64
+		for msgIndex, msg := range sdkTx.GetMsgs() {
+			ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
+			if !ok {
+				continue
+			}
+			if ethMsg.Hash() != hash {
+				var gasUsed uint64
+				if txResults[txIndex].Code != 0 {
+					gasUsed = ethMsg.GetGas()
+				} else {
+					parsedTx := txsParsed.GetTxByMsgIndex(msgIndex)
+					if parsedTx == nil {
+						return nil, errorsmod.Wrapf(errortypes.ErrLogic, "parsed tx nil for msgIndex %d", msgIndex)
+					}
+					gasUsed = parsedTx.GasUsed
+				}
+				cumulativeGasUsed += gasUsed
+				ethTxIndex++
+				continue
+			}
+
+			msgIdx, err := ethermint.SafeUint32(msgIndex)
+			if err != nil {
+				return nil, err
+			}
+
+			res := &ethermint.TxResult{
+				Height:     block.Height,
+				TxIndex:    txIdx,
+				MsgIndex:   msgIdx,
+				EthTxIndex: ethTxIndex,
+			}
+			if txResults[txIndex].Code != 0 {
+				res.GasUsed = ethMsg.GetGas()
+				res.Failed = true
+			} else {
+				parsedTx := txsParsed.GetTxByMsgIndex(msgIndex)
+				if parsedTx == nil {
+					return nil, errorsmod.Wrapf(errortypes.ErrLogic, "parsed tx nil for msgIndex %d", msgIndex)
+				}
+				res.GasUsed = parsedTx.GasUsed
+				res.Failed = parsedTx.Failed
+			}
+			cumulativeGasUsed += res.GasUsed
+			res.CumulativeGasUsed = cumulativeGasUsed
+			return res, nil
+		}
+	}
+
+	return nil, nil
+}
+
 // GetTransactionReceipt returns the transaction receipt identified by hash. It takes an optional resBlock, if nil then the method will fetch it.
 func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.ResultBlock) (map[string]interface{}, error) {
 	b.logger.Debug("eth_getTransactionReceipt", "hash", hash)
 
-	res, err := b.GetTxByEthHash(hash)
-	if err != nil {
-		b.logger.Debug("tx not found", "hash", hash, "error", err.Error())
-		return nil, nil
-	}
-	if resBlock == nil {
+	var res *ethermint.TxResult
+	var blockRes *tmrpctypes.ResultBlockResults
+	var err error
+
+	if resBlock != nil {
+		blockRes, err = b.TendermintBlockResultByNumber(&resBlock.Block.Height)
+		if err != nil {
+			b.logger.Debug("failed to retrieve block results", "height", resBlock.Block.Height, "error", err.Error())
+			return nil, nil
+		}
+		// Prefer the tx indexer when it refers to this exact block. If the same eth tx hash was
+		// included again in a later block, the KV index only keeps the latest inclusion; rebuild from
+		// the block when heights disagree or the hash is missing from the index.
+		indexed, errIdx := b.GetTxByEthHash(hash)
+		if errIdx == nil && indexed.Height == resBlock.Block.Height {
+			res = indexed
+		} else {
+			res, err = b.txResultFromBlockHash(resBlock, blockRes, hash)
+			if err != nil {
+				return nil, err
+			}
+			if res == nil {
+				return nil, nil
+			}
+		}
+	} else {
+		res, err = b.GetTxByEthHash(hash)
+		if err != nil {
+			b.logger.Debug("tx not found", "hash", hash, "error", err.Error())
+			return nil, nil
+		}
 		resBlock, err = b.TendermintBlockByNumber(rpctypes.BlockNumber(res.Height))
 		if err != nil {
 			b.logger.Debug("block not found", "height", res.Height, "error", err.Error())
+			return nil, nil
+		}
+		blockRes, err = b.TendermintBlockResultByNumber(&res.Height)
+		if err != nil {
+			b.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
 			return nil, nil
 		}
 	}
@@ -196,11 +312,6 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.R
 	}
 
 	var cumulativeGasUsed uint64
-	blockRes, err := b.TendermintBlockResultByNumber(&res.Height)
-	if err != nil {
-		b.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
-		return nil, nil
-	}
 	if int(res.TxIndex) >= len(blockRes.TxsResults) {
 		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", res.TxIndex, len(blockRes.TxsResults))
 	}

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -244,7 +244,9 @@ func (b *Backend) txResultFromBlockHash(
 
 // GetTransactionReceipt returns the transaction receipt identified by hash.
 // It takes optional resBlock and blockRes; if nil the method will fetch them.
-func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.ResultBlock, blockRes *tmrpctypes.ResultBlockResults) (map[string]interface{}, error) {
+func (b *Backend) GetTransactionReceipt(
+	hash common.Hash, resBlock *tmrpctypes.ResultBlock, blockRes *tmrpctypes.ResultBlockResults,
+) (map[string]interface{}, error) {
 	b.logger.Debug("eth_getTransactionReceipt", "hash", hash)
 
 	var res *ethermint.TxResult

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -589,7 +589,7 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 			err := suite.backend.indexer.IndexBlock(tc.block, tc.blockResult)
 			suite.Require().NoError(err)
 
-			txReceipt, err := suite.backend.GetTransactionReceipt(tc.tx.Hash(), nil)
+			txReceipt, err := suite.backend.GetTransactionReceipt(tc.tx.Hash(), nil, nil)
 			if tc.expPass {
 				suite.Require().NoError(err)
 				suite.Require().Equal(txReceipt, tc.expTxReceipt)
@@ -652,7 +652,7 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt_BlockScopedWhenIndexerO
 	blockRes1 := &tmrpctypes.ResultBlockResults{Height: 1, TxsResults: []*abci.ExecTxResult{execTx}}
 	client.On("BlockResults", rpctypes.ContextWithHeight(1), mock.AnythingOfType("*int64")).Return(blockRes1, nil)
 
-	receipt, err := suite.backend.GetTransactionReceipt(txHash, resBlock1)
+	receipt, err := suite.backend.GetTransactionReceipt(txHash, resBlock1, blockRes1)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(receipt)
 	suite.Require().Equal(hexutil.Uint64(1), receipt["blockNumber"])

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -19,6 +19,7 @@ import (
 	ethermint "github.com/evmos/ethermint/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"github.com/holiman/uint256"
+	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -597,6 +598,69 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 			}
 		})
 	}
+}
+
+// TestGetTransactionReceipt_BlockScopedWhenIndexerOverwritten documents the fix for duplicate eth tx hashes:
+// the KV indexer only stores the latest inclusion per hash. eth_getBlockReceipts (and GetTransactionReceipt with
+// an explicit block) must still return receipts for that block, not the overwritten indexer height.
+func (suite *BackendTestSuite) TestGetTransactionReceipt_BlockScopedWhenIndexerOverwritten() {
+	suite.SetupTest()
+
+	msgEthereumTx, txBz := suite.buildEthereumTx()
+	txHash := msgEthereumTx.Hash()
+
+	execTx := &abci.ExecTxResult{
+		Code:    0,
+		GasUsed: 21000,
+		Events: []abci.Event{
+			{Type: evmtypes.EventTypeEthereumTx, Attributes: []abci.EventAttribute{
+				{Key: "ethereumTxHash", Value: txHash.Hex()},
+				{Key: "txIndex", Value: "0"},
+				{Key: "amount", Value: "1000"},
+				{Key: "txGasUsed", Value: "21000"},
+				{Key: "txHash", Value: ""},
+				{Key: "recipient", Value: "0x775b87ef5D82ca211811C1a02CE0fE0CA3a455d7"},
+			}},
+		},
+	}
+
+	block1 := &types.Block{Header: types.Header{Height: 1}, Data: types.Data{Txs: []types.Tx{txBz}}}
+	block2 := &types.Block{Header: types.Header{Height: 2}, Data: types.Data{Txs: []types.Tx{txBz}}}
+
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, tmlog.NewNopLogger(), suite.backend.clientCtx)
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(block1, []*abci.ExecTxResult{execTx}))
+	r1, err := suite.backend.indexer.GetByTxHash(txHash)
+	suite.Require().NoError(err)
+	suite.Require().Equal(int64(1), r1.Height)
+
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(block2, []*abci.ExecTxResult{execTx}))
+	r2, err := suite.backend.indexer.GetByTxHash(txHash)
+	suite.Require().NoError(err)
+	suite.Require().Equal(int64(2), r2.Height)
+
+	var header metadata.MD
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	RegisterParams(queryClient, &header, 1)
+	RegisterParamsWithoutHeader(queryClient, 1)
+
+	resBlock1, err := RegisterBlock(client, 1, txBz)
+	suite.Require().NoError(err)
+
+	// TendermintBlockByNumber / BlockResults use b.ctx (ContextWithHeight(1) from SetupTest), not ContextWithHeight(requestedHeight).
+	blockRes1 := &tmrpctypes.ResultBlockResults{Height: 1, TxsResults: []*abci.ExecTxResult{execTx}}
+	client.On("BlockResults", rpctypes.ContextWithHeight(1), mock.AnythingOfType("*int64")).Return(blockRes1, nil)
+
+	receipt, err := suite.backend.GetTransactionReceipt(txHash, resBlock1)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(receipt)
+	suite.Require().Equal(hexutil.Uint64(1), receipt["blockNumber"])
+
+	receipts, err := suite.backend.GetBlockReceipts(rpctypes.BlockNumber(1))
+	suite.Require().NoError(err)
+	suite.Require().Len(receipts, 1)
+	suite.Require().Equal(hexutil.Uint64(1), receipts[0]["blockNumber"])
 }
 
 func (suite *BackendTestSuite) TestGetGasUsed() {

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -639,11 +639,7 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt_BlockScopedWhenIndexerO
 	suite.Require().NoError(err)
 	suite.Require().Equal(int64(2), r2.Height)
 
-	var header metadata.MD
-	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 	client := suite.backend.clientCtx.Client.(*mocks.Client)
-	RegisterParams(queryClient, &header, 1)
-	RegisterParamsWithoutHeader(queryClient, 1)
 
 	resBlock1, err := RegisterBlock(client, 1, txBz)
 	suite.Require().NoError(err)
@@ -654,13 +650,11 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt_BlockScopedWhenIndexerO
 
 	receipt, err := suite.backend.GetTransactionReceipt(txHash, resBlock1, blockRes1)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(receipt)
-	suite.Require().Equal(hexutil.Uint64(1), receipt["blockNumber"])
+	suite.Require().Nil(receipt) // overwritten index → skip, receipt belongs to block 2
 
 	receipts, err := suite.backend.GetBlockReceipts(rpctypes.BlockNumber(1))
 	suite.Require().NoError(err)
-	suite.Require().Len(receipts, 1)
-	suite.Require().Equal(hexutil.Uint64(1), receipts[0]["blockNumber"])
+	suite.Require().Empty(receipts) // no receipts for block 1 — tx re-indexed under block 2
 }
 
 func (suite *BackendTestSuite) TestGetGasUsed() {

--- a/rpc/namespaces/ethereum/eth/api.go
+++ b/rpc/namespaces/ethereum/eth/api.go
@@ -196,7 +196,7 @@ func (e *PublicAPI) GetTransactionCount(address common.Address, blockNrOrHash rp
 func (e *PublicAPI) GetTransactionReceipt(hash common.Hash) (map[string]interface{}, error) {
 	hexTx := hash.Hex()
 	e.logger.Debug("eth_getTransactionReceipt", "hash", hexTx)
-	return e.backend.GetTransactionReceipt(hash, nil)
+	return e.backend.GetTransactionReceipt(hash, nil, nil)
 }
 
 // GetBlockTransactionCountByHash returns the number of transactions in the block identified by hash.


### PR DESCRIPTION
## Summary

This PR fixes legacy tx executing issue when it run out of the block gas. and then the same exactly the same tx executed success in later block. It causes eth_getBlockReceipts call crashes in the height included the problematic tx due to the indexer return the later tx receipt for it.

## Solution

- **Index boundary check in GetTransactionReceipt**: back port https://github.com/crypto-org-chain/ethermint/pull/861

- **KV index overwrite handling**: When the same Ethereum tx hash is re-included in a later block, the KV index only retains the latest height. `GetTransactionReceipt` now returns empty receipts when the indexed height differs from the requested block.