### PR TITLE
fix(rpc): fix race condition in stream ReadBlocking

### DIFF
--- a/rpc/stream/cond.go
+++ b/rpc/stream/cond.go
@@ -15,12 +15,18 @@ func NewCond() *Cond {
 	return &Cond{ch: make(chan struct{})}
 }
 
-// Wait returns true if the condition is signaled, false if the context is canceled
-func (c *Cond) Wait(ctx context.Context) bool {
+// WaitChan returns the current wait channel.
+// Capture this while holding relevant locks to avoid missing broadcasts
+// between releasing the lock and starting to wait.
+func (c *Cond) WaitChan() <-chan struct{} {
 	c.mu.Lock()
 	ch := c.ch
 	c.mu.Unlock()
+	return ch
+}
 
+// WaitOnChan waits on a previously captured channel, returns true if signaled, false if canceled.
+func (c *Cond) WaitOnChan(ctx context.Context, ch <-chan struct{}) bool {
 	select {
 	case <-ch:
 		return true

--- a/rpc/stream/stream.go
+++ b/rpc/stream/stream.go
@@ -130,8 +130,11 @@ func (s *Stream[V]) ReadBlocking(ctx context.Context, offset int) ([]V, int) {
 			return items, offset
 		}
 
+		// Capture the wait channel before releasing the read lock to avoid
+		// missing a broadcast that happens between unlock and wait.
+		waitCh := s.cond.WaitChan()
 		s.mutex.RUnlock()
-		r := s.cond.Wait(ctx)
+		r := s.cond.WaitOnChan(ctx, waitCh)
 		s.mutex.RLock()
 
 		if !r {


### PR DESCRIPTION
## Summary
- Fix missed-wakeup race in `ReadBlocking` where a `Broadcast` between releasing the read lock and capturing the `Cond` wait channel could cause subscribers to block indefinitely, missing the last item(s).
- Split `Cond.Wait` into `WaitChan` + `WaitOnChan` so the channel is captured while the read lock is still held.
- Fixes flaky `TestStreamReadBlocking` (expected 32, got 31).
