### PR TITLE
chore(dep): update go 1.25.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/dependabot-update-all.yml
+++ b/.github/workflows/dependabot-update-all.yml
@@ -26,7 +26,7 @@ jobs:
           token: "${{ steps.app-token.outputs.token }}"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - name: Extract updated dependency
         id: deps

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Setup Go"
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - name: "Checkout Repository"
         uses: actions/checkout@v6

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - name: release dry run
         run: make release-dry-run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       # Required: setup-go, for all versions v3.0.0+ of golangci-lint
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
@@ -154,7 +154,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
@@ -174,7 +174,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
@@ -194,7 +194,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
@@ -214,7 +214,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.8"
           check-latest: true
       - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ build-all: tools build lint test vulncheck
 ###############################################################################
 
 PACKAGE_NAME:=github.com/evmos/ethermint
-GOLANG_CROSS_VERSION = v1.25.0
+GOLANG_CROSS_VERSION = v1.25.8
 GOPATH ?= '$(HOME)/go'
 release-dry-run:
 	docker run \

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ parent:
 
 Ethermint is a scalable and interoperable Ethereum library, built on Proof-of-Stake with fast-finality using the [Cosmos SDK](https://github.com/cosmos/cosmos-sdk/) which runs on top of [Tendermint Core](https://github.com/tendermint/tendermint) consensus engine.
 
-**Note**: Requires [Go 1.25.0+](https://golang.org/dl/)
+**Note**: Requires [Go 1.25.8+](https://golang.org/dl/)
 
 ## Installation
 

--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,7 @@ buildGoApplication rec {
   pwd = src; # needed to support replace
   subPackages = [ "cmd/ethermintd" ];
   CGO_ENABLED = "1";
+  GOTOOLCHAIN = "local";
 
   meta = with lib; {
     description = "Ethermint is a scalable and interoperable Ethereum library, built on Proof-of-Stake with fast-finality using the Cosmos SDK which runs on top of Tendermint Core consensus engine.";

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/54170c54449ea4d6725efd30d719c5e505f1c10e";
     flake-utils.url = "github:numtide/flake-utils";
     poetry2nix = {
       url = "github:nix-community/poetry2nix";

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evmos/ethermint
 
-go 1.25.0
+go 1.25.8
 
 require (
 	cosmossdk.io/api v0.9.2
@@ -38,6 +38,7 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.11.1
+	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
@@ -211,7 +212,6 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
-	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -365,8 +365,8 @@ schema = 3
     version = "v0.0.1"
     hash = "sha256-KrExYovtUQrHGI1mPQf57jGw8soz7eWOC2xqEaV0uGk="
   [mod."github.com/google/pprof"]
-    version = "v0.0.0-20250403155104-27863c87afa6"
-    hash = "sha256-6dezHRvyMOT/3I5SzKcvXGsbeZ27YIBmjnAKd5+Hijc="
+    version = "v0.0.0-20260115054156-294ebfa9ad83"
+    hash = "sha256-fhalKl/thSt1gdsHZmFyNGF1Gwxb0YLXV0pBv65EZjE="
   [mod."github.com/google/s2a-go"]
     version = "v0.1.9"
     hash = "sha256-0AdSpSTso4bATmM/9qamWzKrVtOLDf7afvDhoiT/UpA="
@@ -518,11 +518,11 @@ schema = 3
     version = "v0.0.5"
     hash = "sha256-/5i70IkH/qSW5KjGzv8aQNKh9tHoz98tqtL0K2DMFn4="
   [mod."github.com/onsi/ginkgo/v2"]
-    version = "v2.27.5"
-    hash = "sha256-4YtMCQDR+odfRReIah0jHLXFdG8UyX+EOaDT00XpMr0="
+    version = "v2.28.0"
+    hash = "sha256-p5cif8IrShko0DyGHkdjnDaHc+S8ZiQ9dKsOz8nogzQ="
   [mod."github.com/onsi/gomega"]
-    version = "v1.39.0"
-    hash = "sha256-in2eEUjcDC3JGDSAQxBI/mWdT0E2X1yCBKoGXemlWaE="
+    version = "v1.39.1"
+    hash = "sha256-ZlbQhUVwQBzmhBWCQ9iPWoJOVr+OqqIHB4iCNDFMEds="
   [mod."github.com/pelletier/go-toml/v2"]
     version = "v2.2.4"
     hash = "sha256-8qQIPldbsS5RO8v/FW/se3ZsAyvLzexiivzJCbGRg2Q="
@@ -727,17 +727,17 @@ schema = 3
     version = "v0.17.0"
     hash = "sha256-avV63nZlJxuo3/LLBKQ2a96Nn1wflNtc1Dr7GSPbHAs="
   [mod."golang.org/x/crypto"]
-    version = "v0.46.0"
-    hash = "sha256-I8N/spcw3/h0DFA+V1WK38HctckWIB9ep93DEVCALxU="
+    version = "v0.47.0"
+    hash = "sha256-78iRvMmPZVTBrIk30yGpAO11kVC5TLR1zGW85gFLHk4="
   [mod."golang.org/x/exp"]
     version = "v0.0.0-20250305212735-054e65f0b394"
     hash = "sha256-Vgt/CNx/xJYxiKKu0PI7ZSiL/SOfXI4di3Mcyge3aw4="
   [mod."golang.org/x/mod"]
-    version = "v0.31.0"
-    hash = "sha256-ZVNmaZADgM3+30q9rW8q4gP6ySkT7r1eb4vrHIlpCjM="
+    version = "v0.32.0"
+    hash = "sha256-4gbgIqTOo0vcYV3l4MIwmT/h8H9PXmcfrJ3z4B26Zl0="
   [mod."golang.org/x/net"]
-    version = "v0.48.0"
-    hash = "sha256-oZpddsiJwWCH3Aipa+XXpy7G/xHY5fEagUSok7T0bXE="
+    version = "v0.49.0"
+    hash = "sha256-arK6PWwO9tQUJVb57QXUEXfgcB6ISI6qjVB0eC4zcnw="
   [mod."golang.org/x/oauth2"]
     version = "v0.32.0"
     hash = "sha256-eTVnWxQSapzqjaTxEiHYE6OSsVWEBi3ZWBzTYnAMnUE="
@@ -745,11 +745,11 @@ schema = 3
     version = "v0.19.0"
     hash = "sha256-RbRZ+sKZUurOczGhhzOoY/sojTlta3H9XjL4PXX/cno="
   [mod."golang.org/x/sys"]
-    version = "v0.39.0"
-    hash = "sha256-dxTBu/JAWUkPbjFIXXRFdhQWyn+YyEpIC+tWqGo0Y6U="
+    version = "v0.40.0"
+    hash = "sha256-KDe+wMr7dfMFwKMJEljzk+f82pQWFFPoFHivjD7qJGg="
   [mod."golang.org/x/term"]
-    version = "v0.38.0"
-    hash = "sha256-46mX91XGJqii6SUESiU5mLVJDBOfKYCp+408m91hrMw="
+    version = "v0.39.0"
+    hash = "sha256-diP4VknZDlJmhGQdcsXwI2+sFayQdsILFuxK1FBPaUE="
   [mod."golang.org/x/text"]
     version = "v0.33.0"
     hash = "sha256-XdA6D39ESuJkaaM/SRBnqZzjKUwi6Gbt1Si1nvauTr4="
@@ -757,8 +757,8 @@ schema = 3
     version = "v0.12.0"
     hash = "sha256-Cp3oxrCMH2wyxjzr5SHVmyhgaoUuSl56Uy00Q7DYEpw="
   [mod."golang.org/x/tools"]
-    version = "v0.40.0"
-    hash = "sha256-ksmhTnH9btXKiRbbE0KGh02nbeNqNBQKcfwvx9dE7t0="
+    version = "v0.41.0"
+    hash = "sha256-/Plnksa1jSr4jYJc2oCH9fcjGbWocM7EYposMP0tScQ="
   [mod."google.golang.org/api"]
     version = "v0.247.0"
     hash = "sha256-UzTtydHmNqh1OXbxcN5qNKQxb5dV6h2Mo6DH4P219Ec="

--- a/networks/local/ethermintnode/Dockerfile
+++ b/networks/local/ethermintnode/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.0 as build-env
+FROM golang:1.25.8 as build-env
 
 # Install minimum necessary dependencies
 ENV PACKAGES curl make git libc-dev bash gcc
@@ -15,7 +15,7 @@ COPY . .
 RUN make build-linux
 
 # Final image
-FROM golang:1.25.0 as final
+FROM golang:1.25.8 as final
 
 WORKDIR /
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cf79b5735b34d25bb8ee55c90356e72696e7cb3",
-        "sha256": "0ijcv5w5x31vir5473qfxwy81vafgyy2amlh14n9g9pkzj9wd8p0",
+        "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
+        "sha256": "0ayx6v3wwvqpdjkbfnbgyp7rwnsypgn6willidza61x9ilmxkqdp",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/9cf79b5735b34d25bb8ee55c90356e72696e7cb3.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/54170c54449ea4d6725efd30d719c5e505f1c10e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {

--- a/tests/integration_tests/spec/README.md
+++ b/tests/integration_tests/spec/README.md
@@ -1,4 +1,3 @@
 # execution-apis
 
 The specs are copied from the [ethereum/execution-apis](https://github.com/ethereum/execution-apis/tree/main/tests) repository.
-


### PR DESCRIPTION
The golang 1.25.1 to 1.25.8 have some patches in `net/http`, `net/url` which is using in ethermint project.  
Should update the golang dependency to patched version for avoiding network security issues.

The Release log of go1.25:
https://go.dev/doc/devel/release#go1.25.0 