### PR TITLE
fix(rpc): use block-wide eth cumulative gas in receipts

### DIFF
--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -114,7 +114,7 @@ func (b *Backend) GetBlockReceipts(blockNum rpctypes.BlockNumber) ([]map[string]
 
 	res := make([]map[string]interface{}, 0, len(entries))
 	for _, entry := range entries {
-		receipt, err := b.buildReceiptDirect(entry.hash, resBlock, blockRes, entry.txResult, entry.ethMsg)
+		receipt, err := b.buildReceiptDirect(resBlock, blockRes, entry.txResult, entry.ethMsg)
 		if err != nil {
 			return nil, err
 		}

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -107,11 +107,14 @@ func (b *Backend) GetBlockReceipts(blockNum rpctypes.BlockNumber) ([]map[string]
 		return nil, err
 	}
 
-	txHashes := b.TransactionHashesFromTendermintBlock(resBlock, blockRes)
+	entries, err := b.buildReceiptEntriesFromBlock(resBlock, blockRes)
+	if err != nil {
+		return nil, err
+	}
 
-	res := make([]map[string]interface{}, 0, len(txHashes))
-	for _, txHash := range txHashes {
-		receipt, err := b.GetTransactionReceipt(txHash, resBlock)
+	res := make([]map[string]interface{}, 0, len(entries))
+	for _, entry := range entries {
+		receipt, err := b.buildReceiptDirect(entry.hash, resBlock, blockRes, entry.txResult, entry.ethMsg)
 		if err != nil {
 			return nil, err
 		}

--- a/rpc/backend/blocks_test.go
+++ b/rpc/backend/blocks_test.go
@@ -1671,11 +1671,7 @@ func (suite *BackendTestSuite) TestEthBlockReceipts() {
 		{
 			"fail - Receipts do not match ",
 			func() {
-				var header metadata.MD
-				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
-				RegisterParams(queryClient, &header, 1)
-				RegisterParamsWithoutHeader(queryClient, 1)
 				RegisterBlock(client, 1, txBz)
 				RegisterBlockResults(client, 1)
 			},
@@ -1702,11 +1698,7 @@ func (suite *BackendTestSuite) TestEthBlockReceipts() {
 		{
 			"Success - Receipts match",
 			func() {
-				var header metadata.MD
-				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
-				RegisterParams(queryClient, &header, 1)
-				RegisterParamsWithoutHeader(queryClient, 1)
 				RegisterBlock(client, 1, txBz)
 				RegisterBlockResults(client, 1)
 			},

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
+	abci "github.com/cometbft/cometbft/abci/types"
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -158,8 +159,42 @@ func (b *Backend) GetGasUsed(res *ethermint.TxResult, gas uint64) uint64 {
 
 // GetTransactionReceipt returns the transaction receipt identified by hash. It takes an optional resBlock, if nil then the method will fetch it.
 func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.ResultBlock) (map[string]interface{}, error) {
+	return b.getTransactionReceipt(hash, resBlock, nil)
+}
+
+func (b *Backend) getTransactionReceipt(
+	hash common.Hash,
+	resBlock *tmrpctypes.ResultBlock,
+	blockRes *tmrpctypes.ResultBlockResults,
+) (map[string]interface{}, error) {
 	b.logger.Debug("eth_getTransactionReceipt", "hash", hash)
 
+	// Block-scoped path: rebuild receipt directly from block and block result.
+	if resBlock != nil {
+		if resBlock.Block == nil {
+			return nil, nil
+		}
+		var err error
+		if blockRes == nil {
+			blockRes, err = b.TendermintBlockResultByNumber(&resBlock.Block.Height)
+			if err != nil {
+				b.logger.Debug("failed to retrieve block results", "height", resBlock.Block.Height, "error", err.Error())
+				return nil, err
+			}
+		}
+
+		res, ethMsg, err := b.buildReceiptFromBlock(resBlock, blockRes, hash)
+		if err != nil {
+			return nil, err
+		}
+		if res == nil {
+			return nil, nil
+		}
+
+		return b.buildReceiptDirect(hash, resBlock, blockRes, res, ethMsg)
+	}
+
+	// Standalone path remains indexer-based because no block context is provided.
 	res, err := b.GetTxByEthHash(hash)
 	if err != nil {
 		b.logger.Debug("tx not found", "hash", hash, "error", err.Error())
@@ -169,29 +204,19 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.R
 		b.logger.Debug("tx not found in indexer", "hash", hash)
 		return nil, nil
 	}
-	if resBlock == nil {
-		resBlock, err = b.TendermintBlockByNumber(rpctypes.BlockNumber(res.Height))
-		if err != nil {
-			b.logger.Debug("block not found", "height", res.Height, "error", err.Error())
-			return nil, nil
-		}
+
+	resBlock, err = b.TendermintBlockByNumber(rpctypes.BlockNumber(res.Height))
+	if err != nil {
+		b.logger.Debug("block not found", "height", res.Height, "error", err.Error())
+		return nil, nil
 	}
-	var blockRes *tmrpctypes.ResultBlockResults
-	if res.Height == resBlock.Block.Height {
-		blockRes, err = b.TendermintBlockResultByNumber(&res.Height)
-		if err != nil {
-			b.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
-			return nil, nil
-		}
-	} else {
-		res, blockRes, err = b.txResultFromBlockHash(resBlock, hash)
-		if err != nil {
-			return nil, err
-		}
-		if res == nil {
-			return nil, nil
-		}
+
+	blockRes, err = b.TendermintBlockResultByNumber(&res.Height)
+	if err != nil {
+		b.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
+		return nil, nil
 	}
+
 	if int(res.TxIndex) >= len(resBlock.Block.Txs) {
 		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(resBlock.Block.Txs))
 	}
@@ -207,6 +232,139 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash, resBlock *tmrpctypes.R
 	ethMsg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
 	if !ok {
 		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
+	}
+
+	return b.buildReceiptDirect(hash, resBlock, blockRes, res, ethMsg)
+}
+
+func (b *Backend) buildReceiptFromBlock(
+	resBlock *tmrpctypes.ResultBlock,
+	blockRes *tmrpctypes.ResultBlockResults,
+	hash common.Hash,
+) (*ethermint.TxResult, *evmtypes.MsgEthereumTx, error) {
+	entries, err := b.buildReceiptEntriesFromBlock(resBlock, blockRes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, entry := range entries {
+		if entry.hash == hash {
+			return entry.txResult, entry.ethMsg, nil
+		}
+	}
+
+	return nil, nil, nil
+}
+
+type receiptEntry struct {
+	hash     common.Hash
+	txResult *ethermint.TxResult
+	ethMsg   *evmtypes.MsgEthereumTx
+}
+
+func (b *Backend) buildReceiptEntriesFromBlock(
+	resBlock *tmrpctypes.ResultBlock,
+	blockRes *tmrpctypes.ResultBlockResults,
+) ([]receiptEntry, error) {
+	if resBlock == nil || resBlock.Block == nil || blockRes == nil {
+		return nil, nil
+	}
+
+	entries := make([]receiptEntry, 0, len(resBlock.Block.Txs))
+	// Keep eth tx index assignment consistent with KV indexer.
+	var ethTxIndex int32
+	for txIndex, txBz := range resBlock.Block.Txs {
+		if txIndex >= len(blockRes.TxsResults) {
+			return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", txIndex, len(blockRes.TxsResults))
+		}
+
+		result := blockRes.TxsResults[txIndex]
+		if !rpctypes.TxSuccessOrExceedsBlockGasLimit(result) {
+			continue
+		}
+
+		tx, err := b.clientCtx.TxConfig.TxDecoder()(txBz)
+		if err != nil {
+			b.logger.Debug("failed to decode transaction in block", "height", resBlock.Block.Height, "error", err.Error())
+			continue
+		}
+
+		var parsed *rpctypes.ParsedTxs
+		if result.Code == abci.CodeTypeOK {
+			parsed, err = rpctypes.ParseTxResult(result, tx)
+			if err != nil {
+				b.logger.Debug("failed to parse tx events", "height", resBlock.Block.Height, "tx-index", txIndex, "error", err.Error())
+				continue
+			}
+		}
+
+		var cumulativeGasUsed uint64
+		for msgIndex, msg := range tx.GetMsgs() {
+			ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
+			if !ok {
+				continue
+			}
+
+			txIdx, err := ethermint.SafeUint32(txIndex)
+			if err != nil {
+				return nil, err
+			}
+			msgIdx, err := ethermint.SafeUint32(msgIndex)
+			if err != nil {
+				return nil, err
+			}
+
+			txResult := &ethermint.TxResult{
+				Height:     resBlock.Block.Height,
+				TxIndex:    txIdx,
+				MsgIndex:   msgIdx,
+				EthTxIndex: ethTxIndex,
+			}
+
+			if result.Code != abci.CodeTypeOK {
+				// Exceed-block-gas tx may not emit ethereum_tx events.
+				txResult.GasUsed = ethMsg.GetGas()
+				txResult.Failed = true
+			} else {
+				parsedTx := parsed.GetTxByMsgIndex(msgIndex)
+				if parsedTx == nil {
+					b.logger.Debug("msg index not found in events", "height", resBlock.Block.Height, "tx-index", txIndex, "msg-index", msgIndex)
+					continue
+				}
+				txResult.GasUsed = parsedTx.GasUsed
+				txResult.Failed = parsedTx.Failed
+			}
+
+			cumulativeGasUsed += txResult.GasUsed
+			txResult.CumulativeGasUsed = cumulativeGasUsed
+
+			entries = append(entries, receiptEntry{
+				hash:     ethMsg.Hash(),
+				txResult: txResult,
+				ethMsg:   ethMsg,
+			})
+			ethTxIndex++
+		}
+	}
+
+	return entries, nil
+}
+
+func (b *Backend) buildReceiptDirect(
+	hash common.Hash,
+	resBlock *tmrpctypes.ResultBlock,
+	blockRes *tmrpctypes.ResultBlockResults,
+	res *ethermint.TxResult,
+	ethMsg *evmtypes.MsgEthereumTx,
+) (map[string]interface{}, error) {
+	if res == nil || ethMsg == nil {
+		return nil, nil
+	}
+	if resBlock == nil || resBlock.Block == nil {
+		return nil, errorsmod.Wrap(errortypes.ErrNotFound, "block not found")
+	}
+	if blockRes == nil {
+		return nil, errorsmod.Wrap(errortypes.ErrNotFound, "block result not found")
 	}
 
 	txData := ethMsg.AsTransaction()

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -293,7 +293,7 @@ func (b *Backend) buildReceiptEntriesFromBlock(
 		if result.Code == abci.CodeTypeOK {
 			parsed, err = rpctypes.ParseTxResult(result, tx)
 			if err != nil {
-				b.logger.Debug("failed to parse tx events", "height", resBlock.Block.Height, "tx-index", txIndex, "error", err.Error())
+				b.logger.Error("failed to parse tx events", "height", resBlock.Block.Height, "tx-index", txIndex, "error", err.Error())
 				continue
 			}
 		}

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -501,60 +501,6 @@ func (b *Backend) buildReceiptDirect(
 	return receipt, nil
 }
 
-func (b *Backend) txResultFromBlockHash(
-	resBlock *tmrpctypes.ResultBlock,
-	hash common.Hash,
-) (*ethermint.TxResult, *tmrpctypes.ResultBlockResults, error) {
-	blockRes, err := b.TendermintBlockResultByNumber(&resBlock.Block.Height)
-	if err != nil {
-		b.logger.Debug("failed to retrieve block results from resultBlock's height", "height", resBlock.Block.Height, "error", err.Error())
-		return nil, nil, err
-	}
-
-	for txIndex, txBz := range resBlock.Block.Txs {
-		tx, err := b.clientCtx.TxConfig.TxDecoder()(txBz)
-		if err != nil {
-			return nil, nil, errorsmod.Wrapf(errortypes.ErrTxDecode, "failed to decode tx: %v", err)
-		}
-
-		if txIndex >= len(blockRes.TxsResults) {
-			return nil, nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", txIndex, len(blockRes.TxsResults))
-		}
-
-		parsed, err := rpctypes.ParseTxResult(blockRes.TxsResults[txIndex], tx)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		parsedTx := parsed.GetTxByHash(hash)
-		if parsedTx == nil {
-			continue
-		}
-
-		msgIndex, err := ethermint.SafeUint32(parsedTx.MsgIndex)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		txIdx, err := ethermint.SafeUint32(txIndex)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		return &ethermint.TxResult{
-			Height:            resBlock.Block.Height,
-			TxIndex:           txIdx,
-			MsgIndex:          msgIndex,
-			EthTxIndex:        parsedTx.EthTxIndex,
-			Failed:            parsedTx.Failed,
-			GasUsed:           parsedTx.GasUsed,
-			CumulativeGasUsed: parsed.AccumulativeGasUsed(parsedTx.MsgIndex),
-		}, blockRes, nil
-	}
-
-	return nil, blockRes, nil
-}
-
 // GetTransactionByBlockHashAndIndex returns the transaction identified by hash and index.
 func (b *Backend) GetTransactionByBlockHashAndIndex(hash common.Hash, idx hexutil.Uint) (*rpctypes.RPCTransaction, error) {
 	b.logger.Debug("eth_getTransactionByBlockHashAndIndex", "hash", hash.Hex(), "index", idx)

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -191,7 +191,7 @@ func (b *Backend) getTransactionReceipt(
 			return nil, nil
 		}
 
-		return b.buildReceiptDirect(hash, resBlock, blockRes, res, ethMsg)
+		return b.buildReceiptDirect(resBlock, blockRes, res, ethMsg)
 	}
 
 	// Standalone path remains indexer-based because no block context is provided.
@@ -234,7 +234,7 @@ func (b *Backend) getTransactionReceipt(
 		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
 	}
 
-	return b.buildReceiptDirect(hash, resBlock, blockRes, res, ethMsg)
+	return b.buildReceiptDirect(resBlock, blockRes, res, ethMsg)
 }
 
 func (b *Backend) buildReceiptFromBlock(
@@ -351,7 +351,6 @@ func (b *Backend) buildReceiptEntriesFromBlock(
 }
 
 func (b *Backend) buildReceiptDirect(
-	hash common.Hash,
 	resBlock *tmrpctypes.ResultBlock,
 	blockRes *tmrpctypes.ResultBlockResults,
 	res *ethermint.TxResult,
@@ -360,6 +359,7 @@ func (b *Backend) buildReceiptDirect(
 	if res == nil || ethMsg == nil {
 		return nil, nil
 	}
+	hash := ethMsg.Hash()
 	if resBlock == nil || resBlock.Block == nil {
 		return nil, errorsmod.Wrap(errortypes.ErrNotFound, "block not found")
 	}

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -194,7 +194,8 @@ func (b *Backend) getTransactionReceipt(
 		return b.buildReceiptDirect(resBlock, blockRes, res, ethMsg)
 	}
 
-	// Standalone path remains indexer-based because no block context is provided.
+	// Standalone path: use indexer only to find block height, then rebuild from block data
+	// so CumulativeGasUsed reflects block-wide eth gas (not Cosmos SDK gas for prior txs).
 	res, err := b.GetTxByEthHash(hash)
 	if err != nil {
 		b.logger.Debug("tx not found", "hash", hash, "error", err.Error())
@@ -210,6 +211,9 @@ func (b *Backend) getTransactionReceipt(
 		b.logger.Debug("block not found", "height", res.Height, "error", err.Error())
 		return nil, nil
 	}
+	if resBlock.Block == nil {
+		return nil, nil
+	}
 
 	blockRes, err = b.TendermintBlockResultByNumber(&res.Height)
 	if err != nil {
@@ -217,24 +221,15 @@ func (b *Backend) getTransactionReceipt(
 		return nil, nil
 	}
 
-	if int(res.TxIndex) >= len(resBlock.Block.Txs) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(resBlock.Block.Txs))
-	}
-	tx, err := b.clientCtx.TxConfig.TxDecoder()(resBlock.Block.Txs[res.TxIndex])
+	txResult, ethMsg, err := b.buildReceiptFromBlock(resBlock, blockRes, hash)
 	if err != nil {
-		b.logger.Debug("decoding failed", "error", err.Error())
-		return nil, errorsmod.Wrapf(errortypes.ErrTxDecode, "failed to decode tx: %v", err)
+		return nil, err
 	}
-	msgs := tx.GetMsgs()
-	if int(res.MsgIndex) >= len(msgs) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
-	}
-	ethMsg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
-	if !ok {
-		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
+	if txResult == nil {
+		return nil, nil
 	}
 
-	return b.buildReceiptDirect(resBlock, blockRes, res, ethMsg)
+	return b.buildReceiptDirect(resBlock, blockRes, txResult, ethMsg)
 }
 
 func (b *Backend) buildReceiptFromBlock(
@@ -273,6 +268,7 @@ func (b *Backend) buildReceiptEntriesFromBlock(
 	entries := make([]receiptEntry, 0, len(resBlock.Block.Txs))
 	// Keep eth tx index assignment consistent with KV indexer.
 	var ethTxIndex int32
+	var cumulativeGasUsed uint64
 	for txIndex, txBz := range resBlock.Block.Txs {
 		if txIndex >= len(blockRes.TxsResults) {
 			return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", txIndex, len(blockRes.TxsResults))
@@ -298,7 +294,6 @@ func (b *Backend) buildReceiptEntriesFromBlock(
 			}
 		}
 
-		var cumulativeGasUsed uint64
 		for msgIndex, msg := range tx.GetMsgs() {
 			ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
 			if !ok {
@@ -373,18 +368,10 @@ func (b *Backend) buildReceiptDirect(
 		return nil, errorsmod.Wrap(errortypes.ErrTxDecode, "failed to unpack tx data")
 	}
 
-	var cumulativeGasUsed uint64
 	if int(res.TxIndex) >= len(blockRes.TxsResults) {
 		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", res.TxIndex, len(blockRes.TxsResults))
 	}
-	for _, txResult := range blockRes.TxsResults[0:res.TxIndex] {
-		gas, err := ethermint.SafeUint64(txResult.GasUsed)
-		if err != nil {
-			return nil, err
-		}
-		cumulativeGasUsed += gas
-	}
-	cumulativeGasUsed += res.CumulativeGasUsed
+	cumulativeGasUsed := res.CumulativeGasUsed
 
 	var status hexutil.Uint
 	if res.Failed {

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -555,7 +555,22 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 				RegisterParams(queryClient, &header, 1)
 				RegisterParamsWithoutHeader(queryClient, 1)
 				RegisterBlock(client, 1, txBz)
-				RegisterBlockResults(client, 1)
+				// Block results must include ethereum_tx events so buildReceiptEntriesFromBlock
+				// can locate the tx; RegisterBlockResults (no events) is insufficient.
+				client.On("BlockResults", rpctypes.ContextWithHeight(1), mock.AnythingOfType("*int64")).
+					Return(&tmrpctypes.ResultBlockResults{
+						Height: 1,
+						TxsResults: []*abci.ExecTxResult{{
+							Code:    0,
+							GasUsed: 21000,
+							Events: []abci.Event{
+								{Type: evmtypes.EventTypeEthereumTx, Attributes: []abci.EventAttribute{
+									{Key: evmtypes.AttributeKeyEthereumTxHash, Value: txHash.Hex()},
+									{Key: evmtypes.AttributeKeyTxIndex, Value: "0"},
+								}},
+							},
+						}},
+					}, nil)
 			},
 			msgEthereumTx,
 			&types.Block{Header: types.Header{Height: 1}, Data: types.Data{Txs: []types.Tx{txBz}}},

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -774,7 +774,10 @@ func (suite *BackendTestSuite) TestBuildReceiptFromBlock_SuccessfulTx() {
 }
 
 func (suite *BackendTestSuite) TestBuildReceiptFromBlock_HashMiss() {
-	_, txBz := suite.buildEthereumTxWithNonceAndGas(0, 100000)
+	// Build a real tx with valid events so an entry IS created, then query a different hash.
+	// Without this, ParseTxResult would return empty results (no events) and the loop
+	// would continue before hash-matching — testing missing events, not an actual hash miss.
+	msgEthereumTx, txBz := suite.buildEthereumTxWithNonceAndGas(0, 100000)
 	resBlock := &tmrpctypes.ResultBlock{
 		Block: types.MakeBlock(1, []types.Tx{txBz}, nil, nil),
 	}
@@ -784,6 +787,15 @@ func (suite *BackendTestSuite) TestBuildReceiptFromBlock_HashMiss() {
 			{
 				Code:    0,
 				GasUsed: 21000,
+				Events: []abci.Event{
+					{
+						Type: evmtypes.EventTypeEthereumTx,
+						Attributes: []abci.EventAttribute{
+							{Key: evmtypes.AttributeKeyEthereumTxHash, Value: msgEthereumTx.Hash().Hex()},
+							{Key: evmtypes.AttributeKeyTxIndex, Value: "0"},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -710,6 +710,219 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt_BlockScopedWhenBlockRes
 	suite.Require().Nil(receipt)
 }
 
+func (suite *BackendTestSuite) TestBuildReceiptFromBlock_BlockGasExceeded() {
+	msgEthereumTx, txBz := suite.buildEthereumTxWithNonceAndGas(0, 45000)
+	resBlock := &tmrpctypes.ResultBlock{
+		Block: types.MakeBlock(1, []types.Tx{txBz}, nil, nil),
+	}
+	blockRes := &tmrpctypes.ResultBlockResults{
+		Height: 1,
+		TxsResults: []*abci.ExecTxResult{
+			{
+				Code: 11,
+				Log:  rpctypes.ExceedBlockGasLimitError,
+			},
+		},
+	}
+
+	res, ethMsg, err := suite.backend.buildReceiptFromBlock(resBlock, blockRes, msgEthereumTx.Hash())
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+	suite.Require().NotNil(ethMsg)
+	suite.Require().Equal(msgEthereumTx.Hash(), ethMsg.Hash())
+	suite.Require().Equal(int64(1), res.Height)
+	suite.Require().Equal(uint32(0), res.TxIndex)
+	suite.Require().Equal(uint32(0), res.MsgIndex)
+	suite.Require().Equal(int32(0), res.EthTxIndex)
+	suite.Require().True(res.Failed)
+	suite.Require().Equal(msgEthereumTx.GetGas(), res.GasUsed)
+	suite.Require().Equal(msgEthereumTx.GetGas(), res.CumulativeGasUsed)
+}
+
+func (suite *BackendTestSuite) TestBuildReceiptFromBlock_SuccessfulTx() {
+	msgEthereumTx, txBz := suite.buildEthereumTxWithNonceAndGas(0, 100000)
+	resBlock := &tmrpctypes.ResultBlock{
+		Block: types.MakeBlock(1, []types.Tx{txBz}, nil, nil),
+	}
+	blockRes := &tmrpctypes.ResultBlockResults{
+		Height: 1,
+		TxsResults: []*abci.ExecTxResult{
+			{
+				Code:    0,
+				GasUsed: 21000,
+				Events: []abci.Event{
+					{
+						Type: evmtypes.EventTypeEthereumTx,
+						Attributes: []abci.EventAttribute{
+							{Key: evmtypes.AttributeKeyEthereumTxHash, Value: msgEthereumTx.Hash().Hex()},
+							{Key: evmtypes.AttributeKeyTxIndex, Value: "0"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	res, ethMsg, err := suite.backend.buildReceiptFromBlock(resBlock, blockRes, msgEthereumTx.Hash())
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+	suite.Require().NotNil(ethMsg)
+	suite.Require().Equal(msgEthereumTx.Hash(), ethMsg.Hash())
+	suite.Require().Equal(uint64(21000), res.GasUsed)
+	suite.Require().Equal(uint64(21000), res.CumulativeGasUsed)
+	suite.Require().False(res.Failed)
+}
+
+func (suite *BackendTestSuite) TestBuildReceiptFromBlock_HashMiss() {
+	_, txBz := suite.buildEthereumTxWithNonceAndGas(0, 100000)
+	resBlock := &tmrpctypes.ResultBlock{
+		Block: types.MakeBlock(1, []types.Tx{txBz}, nil, nil),
+	}
+	blockRes := &tmrpctypes.ResultBlockResults{
+		Height: 1,
+		TxsResults: []*abci.ExecTxResult{
+			{
+				Code:    0,
+				GasUsed: 21000,
+			},
+		},
+	}
+
+	res, ethMsg, err := suite.backend.buildReceiptFromBlock(resBlock, blockRes, common.HexToHash("0x1234"))
+	suite.Require().NoError(err)
+	suite.Require().Nil(res)
+	suite.Require().Nil(ethMsg)
+}
+
+func (suite *BackendTestSuite) TestBuildReceiptFromBlock_MixedBlock() {
+	msg1, txBz1 := suite.buildEthereumTxWithNonceAndGas(0, 100000)
+	msg2, txBz2 := suite.buildEthereumTxWithNonceAndGas(1, 35000)
+
+	resBlock := &tmrpctypes.ResultBlock{
+		Block: types.MakeBlock(1, []types.Tx{txBz1, {0x01}, txBz2}, nil, nil),
+	}
+	blockRes := &tmrpctypes.ResultBlockResults{
+		Height: 1,
+		TxsResults: []*abci.ExecTxResult{
+			{
+				Code:    0,
+				GasUsed: 21000,
+				Events: []abci.Event{
+					{
+						Type: evmtypes.EventTypeEthereumTx,
+						Attributes: []abci.EventAttribute{
+							{Key: evmtypes.AttributeKeyEthereumTxHash, Value: msg1.Hash().Hex()},
+							{Key: evmtypes.AttributeKeyTxIndex, Value: "0"},
+						},
+					},
+				},
+			},
+			{
+				Code: 0,
+			},
+			{
+				Code: 11,
+				Log:  rpctypes.ExceedBlockGasLimitError,
+			},
+		},
+	}
+
+	res, ethMsg, err := suite.backend.buildReceiptFromBlock(resBlock, blockRes, msg2.Hash())
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+	suite.Require().Equal(msg2.Hash(), ethMsg.Hash())
+	suite.Require().Equal(uint32(2), res.TxIndex)
+	suite.Require().Equal(int32(1), res.EthTxIndex)
+	suite.Require().True(res.Failed)
+	suite.Require().Equal(msg2.GetGas(), res.GasUsed)
+}
+
+func (suite *BackendTestSuite) TestGetBlockReceipts_BlockGasExceededWithoutIndexer() {
+	msg1, txBz1 := suite.buildEthereumTxWithNonceAndGas(0, 100000)
+	msg2, txBz2 := suite.buildEthereumTxWithNonceAndGas(1, 35000)
+
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	var header metadata.MD
+	RegisterParams(queryClient, &header, 1)
+	RegisterParamsWithoutHeader(queryClient, 1)
+	_, err := RegisterBlockMultipleTxs(client, 1, []types.Tx{txBz1, txBz2})
+	suite.Require().NoError(err)
+
+	blockRes := &tmrpctypes.ResultBlockResults{
+		Height: 1,
+		TxsResults: []*abci.ExecTxResult{
+			{
+				Code:    0,
+				GasUsed: 21000,
+				Events: []abci.Event{
+					{
+						Type: evmtypes.EventTypeEthereumTx,
+						Attributes: []abci.EventAttribute{
+							{Key: evmtypes.AttributeKeyEthereumTxHash, Value: msg1.Hash().Hex()},
+							{Key: evmtypes.AttributeKeyTxIndex, Value: "0"},
+						},
+					},
+				},
+			},
+			{
+				Code: 11,
+				Log:  rpctypes.ExceedBlockGasLimitError,
+			},
+		},
+	}
+	client.On("BlockResults", rpctypes.ContextWithHeight(1), mock.AnythingOfType("*int64")).
+		Return(blockRes, nil)
+	suite.backend.indexer = nil
+
+	receipts, err := suite.backend.GetBlockReceipts(rpctypes.BlockNumber(1))
+	suite.Require().NoError(err)
+	suite.Require().Len(receipts, 2)
+
+	var exceededReceipt map[string]interface{}
+	for _, receipt := range receipts {
+		if receipt["transactionHash"] == msg2.Hash() {
+			exceededReceipt = receipt
+			break
+		}
+	}
+
+	suite.Require().NotNil(exceededReceipt)
+	suite.Require().Equal(hexutil.Uint(ethtypes.ReceiptStatusFailed), exceededReceipt["status"])
+	suite.Require().Equal(hexutil.Uint64(msg2.GetGas()), exceededReceipt["gasUsed"])
+	suite.Require().Equal(hexutil.Uint64(21000+msg2.GetGas()), exceededReceipt["cumulativeGasUsed"])
+}
+
+func (suite *BackendTestSuite) TestGetBlockReceipts_IgnoresIndexerHashMismatch() {
+	msgEthereumTx, txBz := suite.buildEthereumTxWithNonceAndGas(0, 45000)
+
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	var header metadata.MD
+	RegisterParams(queryClient, &header, 1)
+	RegisterParamsWithoutHeader(queryClient, 1)
+	_, err := RegisterBlockMultipleTxs(client, 1, []types.Tx{txBz})
+	suite.Require().NoError(err)
+
+	blockRes := &tmrpctypes.ResultBlockResults{
+		Height: 1,
+		TxsResults: []*abci.ExecTxResult{
+			{
+				Code: 11,
+				Log:  rpctypes.ExceedBlockGasLimitError,
+			},
+		},
+	}
+	client.On("BlockResults", rpctypes.ContextWithHeight(1), mock.AnythingOfType("*int64")).
+		Return(blockRes, nil)
+	suite.backend.indexer = failingLookupIndexer{}
+
+	receipts, err := suite.backend.GetBlockReceipts(rpctypes.BlockNumber(1))
+	suite.Require().NoError(err)
+	suite.Require().Len(receipts, 1)
+	suite.Require().Equal(msgEthereumTx.Hash(), receipts[0]["transactionHash"])
+}
+
 func (suite *BackendTestSuite) TestGetGasUsed() {
 	origin := suite.backend.cfg.JSONRPC.FixRevertGasRefundHeight
 	testCases := []struct {
@@ -760,6 +973,24 @@ func (suite *BackendTestSuite) TestGetGasUsed() {
 			suite.backend.cfg.JSONRPC.FixRevertGasRefundHeight = origin
 		})
 	}
+}
+
+type failingLookupIndexer struct{}
+
+func (failingLookupIndexer) LastIndexedBlock() (int64, error) {
+	return -1, nil
+}
+
+func (failingLookupIndexer) IndexBlock(*types.Block, []*abci.ExecTxResult) error {
+	return nil
+}
+
+func (failingLookupIndexer) GetByTxHash(common.Hash) (*ethermint.TxResult, error) {
+	panic("unexpected indexer GetByTxHash call")
+}
+
+func (failingLookupIndexer) GetByBlockAndIndex(int64, int32) (*ethermint.TxResult, error) {
+	panic("unexpected indexer GetByBlockAndIndex call")
 }
 
 func (suite *BackendTestSuite) TestGetTransactionByHash_SetCodeTxType() {
@@ -871,4 +1102,33 @@ func (suite *BackendTestSuite) buildSetCodeTx() *evmtypes.MsgEthereumTx {
 	msgEthereumTx.From = suite.signerAddress
 
 	return msgEthereumTx
+}
+
+func (suite *BackendTestSuite) buildEthereumTxWithNonceAndGas(nonce uint64, gasLimit uint64) (*evmtypes.MsgEthereumTx, []byte) {
+	msgEthereumTx := evmtypes.NewTx(
+		suite.backend.chainID,
+		nonce,
+		&common.Address{},
+		big.NewInt(0),
+		gasLimit,
+		big.NewInt(1),
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	msgEthereumTx.From = suite.signerAddress
+	err := msgEthereumTx.Sign(ethtypes.LatestSignerForChainID(suite.backend.chainID), suite.signer)
+	suite.Require().NoError(err)
+
+	tx, err := msgEthereumTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aphoton")
+	suite.Require().NoError(err)
+
+	bz, err := suite.backend.clientCtx.TxConfig.TxEncoder()(tx)
+	suite.Require().NoError(err)
+
+	sdkTx, err := suite.backend.clientCtx.TxConfig.TxDecoder()(bz)
+	suite.Require().NoError(err)
+
+	return sdkTx.GetMsgs()[0].(*evmtypes.MsgEthereumTx), bz
 }


### PR DESCRIPTION
Depends on #923.

## Summary

- Fix `CumulativeGasUsed` in receipts — prior code summed Cosmos SDK `GasUsed` for preceding transactions which includes ante-handler overhead and diverges from actual eth gas for multi-msg Cosmos txs
- Move cumulative tracking to block level in `buildReceiptEntriesFromBlock` so `TxResult.CumulativeGasUsed` reflects running eth gas total across the whole block
- Remove the prior-txs summation loop from `buildReceiptDirect`; block-wide cumulative now comes from `TxResult` directly
- Unify the standalone `getTransactionReceipt` path to use `buildReceiptFromBlock` (indexer used only to locate block height); both paths now produce consistent cumulative gas

## Test plan

- [ ] All existing receipt tests pass with no changes to expected values
- [ ] `TestGetTransactionReceipt` mock updated to supply `ethereum_tx` events required by `buildReceiptEntriesFromBlock`