### PR TITLE
fix(rpc): include block-gas-exceeded txs in eth_getBlockReceipts (backport #923 to release/v0.23.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+* (rpc) [#923](https://github.com/crypto-org-chain/ethermint/pull/923) fix(rpc): include block-gas-exceeded txs in `eth_getBlockReceipts` and use block-wide eth `cumulativeGasUsed`.
 * (rpc) [#885](https://github.com/crypto-org-chain/ethermint/pull/885) enforce ws origin allowlist and namespace gating.
 * (rpc) [#870](https://github.com/crypto-org-chain/ethermint/pull/870) fix(rpc): fix eth_getBlockReceipts crash
 * (ante) [#829](https://github.com/crypto-org-chain/ethermint/pull/829) fix: validate payload messages in legacy EIP-712

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -107,11 +107,14 @@ func (b *Backend) GetBlockReceipts(blockNum rpctypes.BlockNumber) ([]map[string]
 		return nil, err
 	}
 
-	txHashes := b.TransactionHashesFromTendermintBlock(resBlock, blockRes)
+	entries, err := b.collectReceiptEntriesFromBlock(resBlock, blockRes, nil)
+	if err != nil {
+		return nil, err
+	}
 
-	res := make([]map[string]interface{}, 0, len(txHashes))
-	for _, txHash := range txHashes {
-		receipt, err := b.GetTransactionReceipt(txHash, resBlock, blockRes)
+	res := make([]map[string]interface{}, 0, len(entries))
+	for _, entry := range entries {
+		receipt, err := b.buildReceiptDirect(resBlock, blockRes, entry.txResult, entry.ethMsg)
 		if err != nil {
 			return nil, err
 		}

--- a/rpc/backend/blocks_test.go
+++ b/rpc/backend/blocks_test.go
@@ -1671,11 +1671,7 @@ func (suite *BackendTestSuite) TestEthBlockReceipts() {
 		{
 			"fail - Receipts do not match ",
 			func() {
-				var header metadata.MD
-				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
-				RegisterParams(queryClient, &header, 1)
-				RegisterParamsWithoutHeader(queryClient, 1)
 				RegisterBlock(client, 1, txBz)
 				RegisterBlockResults(client, 1)
 			},
@@ -1702,11 +1698,7 @@ func (suite *BackendTestSuite) TestEthBlockReceipts() {
 		{
 			"Success - Receipts match",
 			func() {
-				var header metadata.MD
-				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
-				RegisterParams(queryClient, &header, 1)
-				RegisterParamsWithoutHeader(queryClient, 1)
 				RegisterBlock(client, 1, txBz)
 				RegisterBlockResults(client, 1)
 			},

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
+	abci "github.com/cometbft/cometbft/abci/types"
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -339,6 +340,237 @@ func (b *Backend) GetTransactionReceipt(
 		baseFee, err := b.BaseFee(blockRes)
 		if err != nil {
 			// tolerate the error for pruned node.
+			b.logger.Error("fetch basefee failed, node is pruned?", "height", res.Height, "error", err)
+		} else {
+			receipt["effectiveGasPrice"] = hexutil.Big(*ethMsg.GetEffectiveGasPrice(baseFee))
+		}
+	}
+
+	return receipt, nil
+}
+
+type receiptEntry struct {
+	hash     common.Hash
+	txResult *ethermint.TxResult
+	ethMsg   *evmtypes.MsgEthereumTx
+}
+
+// collectReceiptEntriesFromBlock walks the block and builds eth receipt entries.
+// When stopAtHash is non-nil the walk returns early once that hash is found.
+func (b *Backend) collectReceiptEntriesFromBlock(
+	block *tmrpctypes.ResultBlock,
+	blockResults *tmrpctypes.ResultBlockResults,
+	stopAtHash *common.Hash,
+) ([]receiptEntry, error) {
+	if block == nil || block.Block == nil || blockResults == nil {
+		return nil, nil
+	}
+
+	entries := make([]receiptEntry, 0, len(block.Block.Txs))
+	var ethTxIndex int32
+	var cumulativeGasUsed uint64
+	for txIndex, txBz := range block.Block.Txs {
+		if txIndex >= len(blockResults.TxsResults) {
+			return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", txIndex, len(blockResults.TxsResults))
+		}
+
+		result := blockResults.TxsResults[txIndex]
+		if !rpctypes.TxSuccessOrExceedsBlockGasLimit(result) {
+			continue
+		}
+
+		tx, err := b.clientCtx.TxConfig.TxDecoder()(txBz)
+		if err != nil {
+			b.logger.Debug("failed to decode transaction in block", "height", block.Block.Height, "error", err.Error())
+			continue
+		}
+
+		var parsed *rpctypes.ParsedTxs
+		if result.Code == abci.CodeTypeOK {
+			parsed, err = rpctypes.ParseTxResult(result, tx)
+			if err != nil {
+				b.logger.Error("failed to parse tx events", "height", block.Block.Height, "tx-index", txIndex, "error", err.Error())
+				continue
+			}
+		}
+
+		for msgIndex, msg := range tx.GetMsgs() {
+			ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
+			if !ok {
+				continue
+			}
+
+			txIdx, err := ethermint.SafeUint32(txIndex)
+			if err != nil {
+				return nil, err
+			}
+			msgIdx, err := ethermint.SafeUint32(msgIndex)
+			if err != nil {
+				return nil, err
+			}
+
+			txResult := &ethermint.TxResult{
+				Height:     block.Block.Height,
+				TxIndex:    txIdx,
+				MsgIndex:   msgIdx,
+				EthTxIndex: ethTxIndex,
+			}
+
+			if result.Code != abci.CodeTypeOK {
+				// Exceed-block-gas tx may not emit ethereum_tx events.
+				txResult.GasUsed = ethMsg.GetGas()
+				txResult.Failed = true
+			} else {
+				parsedTx := parsed.GetTxByMsgIndex(msgIndex)
+				if parsedTx == nil {
+					b.logger.Debug("msg index not found in events", "height", block.Block.Height, "tx-index", txIndex, "msg-index", msgIndex)
+					continue
+				}
+				txResult.GasUsed = parsedTx.GasUsed
+				txResult.Failed = parsedTx.Failed
+			}
+
+			cumulativeGasUsed += txResult.GasUsed
+			txResult.CumulativeGasUsed = cumulativeGasUsed
+
+			hash := ethMsg.Hash()
+			entries = append(entries, receiptEntry{
+				hash:     hash,
+				txResult: txResult,
+				ethMsg:   ethMsg,
+			})
+			ethTxIndex++
+
+			if stopAtHash != nil && hash == *stopAtHash {
+				return entries, nil
+			}
+		}
+	}
+
+	return entries, nil
+}
+
+// buildReceiptDirect assembles the receipt map from resolved tx data.
+// Caller must set res.CumulativeGasUsed to the block-wide value.
+func (b *Backend) buildReceiptDirect(
+	block *tmrpctypes.ResultBlock,
+	blockResults *tmrpctypes.ResultBlockResults,
+	res *ethermint.TxResult,
+	ethMsg *evmtypes.MsgEthereumTx,
+) (map[string]interface{}, error) {
+	if res == nil || ethMsg == nil {
+		return nil, nil
+	}
+	hash := ethMsg.Hash()
+	if block == nil || block.Block == nil {
+		return nil, errorsmod.Wrap(errortypes.ErrNotFound, "block not found")
+	}
+	if blockResults == nil {
+		return nil, errorsmod.Wrap(errortypes.ErrNotFound, "block result not found")
+	}
+
+	txData := ethMsg.AsTransaction()
+	if txData == nil {
+		b.logger.Error("failed to unpack tx data")
+		return nil, errorsmod.Wrap(errortypes.ErrTxDecode, "failed to unpack tx data")
+	}
+
+	if int(res.TxIndex) >= len(blockResults.TxsResults) {
+		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", res.TxIndex, len(blockResults.TxsResults))
+	}
+
+	var status hexutil.Uint
+	if res.Failed {
+		status = hexutil.Uint(ethtypes.ReceiptStatusFailed)
+	} else {
+		status = hexutil.Uint(ethtypes.ReceiptStatusSuccessful)
+	}
+	chainID, err := b.ChainID()
+	if err != nil {
+		return nil, err
+	}
+
+	from, err := ethMsg.GetSenderLegacy(ethtypes.LatestSignerForChainID(chainID.ToInt()))
+	if err != nil {
+		return nil, err
+	}
+
+	height, err := ethermint.SafeUint64(blockResults.Height)
+	if err != nil {
+		return nil, err
+	}
+	logs, err := evmtypes.DecodeMsgLogsFromEvents(
+		blockResults.TxsResults[res.TxIndex].Data,
+		blockResults.TxsResults[res.TxIndex].Events,
+		int(res.MsgIndex),
+		height,
+	)
+	if err != nil {
+		b.logger.Debug("failed to parse logs", "hash", hash, "error", err.Error())
+	}
+	if logs == nil {
+		logs = []*ethtypes.Log{}
+	}
+
+	if res.EthTxIndex == -1 {
+		// Reachable via TM-indexer fallback (ParseTxIndexerResult) when events
+		// lack the txIndex attribute. Scan the block for a matching hash.
+		msgs := b.EthMsgsFromTendermintBlock(block, blockResults)
+		for i := range msgs {
+			idx, err := ethermint.SafeIntToInt32(i)
+			if err != nil {
+				return nil, err
+			}
+			if msgs[i].Hash() == hash {
+				res.EthTxIndex = idx
+				break
+			}
+		}
+	}
+	if res.EthTxIndex == -1 {
+		return nil, errorsmod.Wrap(errortypes.ErrNotFound, "can't find index of ethereum tx")
+	}
+
+	blockNumber, err := ethermint.SafeUint64(res.Height)
+	if err != nil {
+		return nil, err
+	}
+	transactionIndex, err := ethermint.SafeInt32ToUint64(res.EthTxIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	var bloom ethtypes.Bloom
+	for _, log := range logs {
+		bloom.Add(log.Address.Bytes())
+		for _, b := range log.Topics {
+			bloom.Add(b[:])
+		}
+	}
+
+	receipt := map[string]interface{}{
+		"status":            status,
+		"cumulativeGasUsed": hexutil.Uint64(res.CumulativeGasUsed),
+		"logsBloom":         ethtypes.BytesToBloom(bloom.Bytes()),
+		"logs":              logs,
+		"transactionHash":   hash,
+		"contractAddress":   nil,
+		"gasUsed":           hexutil.Uint64(b.GetGasUsed(res, txData.Gas())),
+		"blockHash":         common.BytesToHash(block.Block.Header.Hash()).Hex(),
+		"blockNumber":       hexutil.Uint64(blockNumber),
+		"transactionIndex":  hexutil.Uint64(transactionIndex),
+		"from":              from,
+		"to":                txData.To(),
+		"type":              hexutil.Uint(txData.Type()),
+	}
+
+	if txData.To() == nil {
+		receipt["contractAddress"] = crypto.CreateAddress(from, txData.Nonce())
+	}
+
+	if txData.Type() == ethtypes.DynamicFeeTxType {
+		baseFee, err := b.BaseFee(blockResults)
+		if err != nil {
 			b.logger.Error("fetch basefee failed, node is pruned?", "height", res.Height, "error", err)
 		} else {
 			receipt["effectiveGasPrice"] = hexutil.Big(*ethMsg.GetEffectiveGasPrice(baseFee))

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -601,8 +601,9 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 }
 
 // TestGetTransactionReceipt_BlockScopedWhenIndexerOverwritten documents the fix for duplicate eth tx hashes:
-// the KV indexer only stores the latest inclusion per hash. eth_getBlockReceipts (and GetTransactionReceipt with
-// an explicit block) must still return receipts for that block, not the overwritten indexer height.
+// the KV indexer only stores the latest inclusion per hash. GetTransactionReceipt with an explicit block
+// still uses the indexer-height guard (returns nil if overwritten), while GetBlockReceipts uses a block-walk
+// and returns the receipt physically present in the block regardless of indexer state.
 func (suite *BackendTestSuite) TestGetTransactionReceipt_BlockScopedWhenIndexerOverwritten() {
 	suite.SetupTest()
 
@@ -640,6 +641,7 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt_BlockScopedWhenIndexerO
 	suite.Require().Equal(int64(2), r2.Height)
 
 	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 
 	resBlock1, err := RegisterBlock(client, 1, txBz)
 	suite.Require().NoError(err)
@@ -648,15 +650,65 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt_BlockScopedWhenIndexerO
 	blockRes1 := &tmrpctypes.ResultBlockResults{Height: 1, TxsResults: []*abci.ExecTxResult{execTx}}
 	client.On("BlockResults", rpctypes.ContextWithHeight(1), mock.AnythingOfType("*int64")).Return(blockRes1, nil)
 
+	var header metadata.MD
+	RegisterParams(queryClient, &header, 1)
+	RegisterParamsWithoutHeader(queryClient, 1)
+
 	receipt, err := suite.backend.GetTransactionReceipt(txHash, resBlock1, blockRes1)
 	suite.Require().NoError(err)
 	suite.Require().Nil(receipt) // overwritten index → skip, receipt belongs to block 2
 
+	// GetBlockReceipts uses block-walk and returns the receipt physically in the block,
+	// regardless of what the KV indexer says.
 	receipts, err := suite.backend.GetBlockReceipts(rpctypes.BlockNumber(1))
 	suite.Require().NoError(err)
-	suite.Require().Empty(receipts) // no receipts for block 1 — tx re-indexed under block 2
+	suite.Require().Len(receipts, 1)
 }
 
+// TestGetBlockReceipts_BlockGasExceeded verifies that eth_getBlockReceipts includes
+// a tx that failed with "exceeds block gas limit" (KV indexer may not have it).
+func (suite *BackendTestSuite) TestGetBlockReceipts_BlockGasExceeded() {
+	suite.SetupTest()
+
+	msgEthereumTx, txBz := suite.buildEthereumTx()
+	txHash := msgEthereumTx.Hash()
+
+	// ExecTxResult with Code=11 (out of block gas): no ethereum_tx events.
+	execTx := &abci.ExecTxResult{
+		Code:    11,
+		Log:     "out of gas in location: block gas meter; gasWanted: 21000",
+		GasUsed: 21000,
+		Events:  []abci.Event{},
+	}
+
+	block := &types.Block{Header: types.Header{Height: 1}, Data: types.Data{Txs: []types.Tx{txBz}}}
+
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, tmlog.NewNopLogger(), suite.backend.clientCtx)
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(block, []*abci.ExecTxResult{execTx}))
+	// Verify the tx hash is indexed (kv_indexer indexes block-gas-exceeded txs directly).
+	res, err := suite.backend.indexer.GetByTxHash(txHash)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	_, err = RegisterBlock(client, 1, txBz)
+	suite.Require().NoError(err)
+
+	blockRes := &tmrpctypes.ResultBlockResults{Height: 1, TxsResults: []*abci.ExecTxResult{execTx}}
+	client.On("BlockResults", rpctypes.ContextWithHeight(1), mock.AnythingOfType("*int64")).Return(blockRes, nil)
+
+	var header metadata.MD
+	RegisterParams(queryClient, &header, 1)
+	RegisterParamsWithoutHeader(queryClient, 1)
+
+	receipts, err := suite.backend.GetBlockReceipts(rpctypes.BlockNumber(1))
+	suite.Require().NoError(err)
+	suite.Require().Len(receipts, 1)
+	suite.Require().Equal(hexutil.Uint(0), receipts[0]["status"]) // ReceiptStatusFailed
+	suite.Require().Equal(txHash, receipts[0]["transactionHash"])
+}
 func (suite *BackendTestSuite) TestGetGasUsed() {
 	origin := suite.backend.cfg.JSONRPC.FixRevertGasRefundHeight
 	testCases := []struct {


### PR DESCRIPTION
## Summary

Backport of #923 to `release/v0.23.x`.

- Add `collectReceiptEntriesFromBlock` + `buildReceiptDirect` to walk block data directly in `GetBlockReceipts`
- `GetBlockReceipts` no longer depends on the KV indexer, so block-gas-exceeded txs are always included
- `cumulativeGasUsed` in block receipts is now eth-only block-wide (excludes cosmos tx gas)
- `GetTransactionReceipt` (3-param) retains its indexer-height guard unchanged
