### PR TITLE
feat(server): add index-eth-tx range subcommand for targeted block re-indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+* (server) [#939](https://github.com/crypto-org-chain/ethermint/pull/939) feat(server): add `index-eth-tx range <start> <end>` subcommand for targeted block re-indexing.
 * (rpc) [#923](https://github.com/crypto-org-chain/ethermint/pull/923) fix(rpc): include block-gas-exceeded txs in `eth_getBlockReceipts` and use block-wide eth `cumulativeGasUsed`.
 * (ci) [#925](https://github.com/crypto-org-chain/ethermint/pull/925) fix(ci): fix dependabot workflows and drain PR backlog
 * (rpc) [#877](https://github.com/crypto-org-chain/ethermint/pull/877) fix(rpc): Fix eth_getBlockReceipts crash and return duplicate transaction

--- a/server/indexer_cmd.go
+++ b/server/indexer_cmd.go
@@ -29,6 +29,8 @@ import (
 	"github.com/evmos/ethermint/indexer"
 )
 
+const directionRange = "range"
+
 func NewIndexTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "index-eth-tx [backward|forward|range <start> <end>]",
@@ -50,10 +52,10 @@ func NewIndexTxCmd() *cobra.Command {
 			}
 
 			direction := args[0]
-			if direction != "backward" && direction != "forward" && direction != "range" {
+			if direction != "backward" && direction != "forward" && direction != directionRange {
 				return fmt.Errorf("unknown index direction, expect: backward|forward|range, got: %s", direction)
 			}
-			if direction == "range" && len(args) != 3 {
+			if direction == directionRange && len(args) != 3 {
 				return fmt.Errorf("range requires exactly two arguments: <start> <end>")
 			}
 
@@ -127,7 +129,7 @@ func NewIndexTxCmd() *cobra.Command {
 						return err
 					}
 				}
-			case "range":
+			case directionRange:
 				start, err := strconv.ParseInt(args[1], 10, 64)
 				if err != nil {
 					return fmt.Errorf("invalid start block: %w", err)

--- a/server/indexer_cmd.go
+++ b/server/indexer_cmd.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -30,16 +31,17 @@ import (
 
 func NewIndexTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "index-eth-tx [backward|forward]",
+		Use:   "index-eth-tx [backward|forward|range <start> <end>]",
 		Short: "Index historical eth txs",
 		Long: `Index historical eth txs, it only support two traverse direction to avoid creating gaps in the indexer db if using arbitrary block ranges:
 		- backward: index the blocks from the first indexed block to the earliest block in the chain, if indexer db is empty, start from the latest block.
 		- forward: index the blocks from the latest indexed block to latest block in the chain.
+		- range <start> <end>: re-index a specific inclusive block range, overwriting any existing entries.
 
 		When start the node, the indexer start from the latest indexed block to avoid creating gap.
         Backward mode should be used most of the time, so the latest indexed block is always up-to-date.
 		`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(1, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			serverCtx := server.GetServerContextFromCmd(cmd)
 			clientCtx, err := client.GetClientQueryContext(cmd)
@@ -48,8 +50,11 @@ func NewIndexTxCmd() *cobra.Command {
 			}
 
 			direction := args[0]
-			if direction != "backward" && direction != "forward" {
-				return fmt.Errorf("unknown index direction, expect: backward|forward, got: %s", direction)
+			if direction != "backward" && direction != "forward" && direction != "range" {
+				return fmt.Errorf("unknown index direction, expect: backward|forward|range, got: %s", direction)
+			}
+			if direction == "range" && len(args) != 3 {
+				return fmt.Errorf("range requires exactly two arguments: <start> <end>")
 			}
 
 			cfg := serverCtx.Config
@@ -118,6 +123,26 @@ func NewIndexTxCmd() *cobra.Command {
 					latest = 0
 				}
 				for i := latest + 1; i <= blockStore.Height(); i++ {
+					if err := indexBlock(i); err != nil {
+						return err
+					}
+				}
+			case "range":
+				start, err := strconv.ParseInt(args[1], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid start block: %w", err)
+				}
+				end, err := strconv.ParseInt(args[2], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid end block: %w", err)
+				}
+				if start <= 0 || end < start {
+					return fmt.Errorf("invalid range: start must be > 0 and end >= start, got %d-%d", start, end)
+				}
+				if end > blockStore.Height() {
+					return fmt.Errorf("end block %d exceeds current chain height %d", end, blockStore.Height())
+				}
+				for i := start; i <= end; i++ {
 					if err := indexBlock(i); err != nil {
 						return err
 					}


### PR DESCRIPTION
## Summary

- Add `index-eth-tx range <start> <end>` subcommand to re-index a specific inclusive block range in the KV indexer, overwriting any existing entries

The block-gas-exceeded fix for `eth_getBlockReceipts` was already merged via #923. This PR adds the missing operator tooling to fix `eth_getTransactionReceipt` for historical blocks that were not indexed by older binaries.

## Motivation

After deploying #923, operators can use `eth_getBlockReceipts` to get block-gas-exceeded txs. But `eth_getTransactionReceipt` (standalone) still returns null for those historical blocks because the KV indexer was never populated. The existing `backward`/`forward` subcommands only fill gaps before the first or after the last indexed block — they don't re-index blocks already within the indexed range.

## Usage

```bash
# Re-index specific problem blocks (node can be running)
cronosd index-eth-tx range 11609995 11609995 --home /chain/.home/
cronosd index-eth-tx range 11609990 11623370 --home /chain/.home/
```

## Enabling KV indexer (required)

```toml
# app.toml
[json-rpc]
enable-indexer = true
```
