### PR TITLE
ci: fix pr_labeler.yml config for actions/labeler@v6 format

### DIFF
--- a/.github/pr_labeler.yml
+++ b/.github/pr_labeler.yml
@@ -1,28 +1,38 @@
 cli:
-  - x/*/client/**/*
+  - changed-files:
+    - any-glob-to-any-file: 'x/*/client/**/*'
 nix:
-  - nix/**
-  - default.nix
-  - docker.nix
-  - flake.nix
-  - sources.nix
-  - testenv.nix
-  - goethereum.nix
-  - golangci-lint.nix
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'nix/**'
+      - 'default.nix'
+      - 'docker.nix'
+      - 'flake.nix'
+      - 'sources.nix'
+      - 'testenv.nix'
+      - 'goethereum.nix'
+      - 'golangci-lint.nix'
 adr:
-  - docs/architecture/**/*
+  - changed-files:
+    - any-glob-to-any-file: 'docs/architecture/**/*'
 build:
-  - Makefile
-  - Dockerfile
-  - docker-compose.yml
-  - scripts/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'Makefile'
+      - 'Dockerfile'
+      - 'docker-compose.yml'
+      - 'scripts/*'
 ci:
-  - .github/**
-  - buf.work.yaml
-  - .golangci.yml
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**'
+      - 'buf.work.yaml'
+      - '.golangci.yml'
 
-# modules  
+# modules
 evm:
-  - x/evm/**/*
+  - changed-files:
+    - any-glob-to-any-file: 'x/evm/**/*'
 feemarket:
-  - x/feemarket/**/*
+  - changed-files:
+    - any-glob-to-any-file: 'x/feemarket/**/*'


### PR DESCRIPTION
## Summary
- `actions/labeler@v6` requires `changed-files` key with glob objects instead of flat glob list
- Updated all 7 labels in `.github/pr_labeler.yml` to v5/v6 schema