### PR TITLE
fix(evm): align debug_trace fee with virtual ante path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (geth) [#957](https://github.com/crypto-org-chain/ethermint/pull/957) feat(geth): update go-ethereum version to `v1.16.9`, enable Osaka hardfork
 * (evm) [#973](https://github.com/crypto-org-chain/ethermint/pull/973) fix: setting evm hooks prevent the stateDB from committing for failed tx
 * (rpc) [#965](https://github.com/crypto-org-chain/ethermint/pull/965) fix(rpc): align `eth_getBlockReceipts` response with execution-apis spec.
+* [#967](https://github.com/crypto-org-chain/ethermint/pull/967) fix(evm): align debug_trace fee with virtual ante path
 
 ## [v0.23.0] - 2026-01-13
 

--- a/x/evm/keeper/gas.go
+++ b/x/evm/keeper/gas.go
@@ -48,8 +48,23 @@ func (k *Keeper) GetEthIntrinsicGas(msg *core.Message, rules params.Rules, isCon
 // returned by the EVM execution, thus ignoring the previous intrinsic gas consumed during in the
 // AnteHandler.
 func (k *Keeper) RefundGas(ctx sdk.Context, msg *core.Message, leftoverGas uint64, denom string) error {
+	return k.RefundGasWithPrice(ctx, msg, leftoverGas, msg.GasPrice, denom)
+}
+
+// RefundGasWithPrice transfers the leftover gas to sender using the provided gas price.
+func (k *Keeper) RefundGasWithPrice(
+	ctx sdk.Context,
+	msg *core.Message,
+	leftoverGas uint64,
+	gasPrice *big.Int,
+	denom string,
+) error {
+	if gasPrice == nil {
+		gasPrice = new(big.Int)
+	}
+
 	// Return EVM tokens for remaining gas, exchanged at the original rate.
-	remaining := new(big.Int).Mul(new(big.Int).SetUint64(leftoverGas), msg.GasPrice)
+	remaining := new(big.Int).Mul(new(big.Int).SetUint64(leftoverGas), gasPrice)
 
 	switch remaining.Sign() {
 	case -1:

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -522,8 +522,8 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 	if req == nil || req.Msg == nil {
 		return nil, status.Error(codes.InvalidArgument, "request and message cannot be empty")
 	}
-	if req.BaseFee != nil {
-		baseFee = big.NewInt(req.BaseFee.Int64())
+	if req.BaseFee != nil && !req.BaseFee.IsNil() {
+		baseFee = req.BaseFee.BigInt()
 	}
 	resultData, err := execTrace(
 		c,

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -911,7 +911,7 @@ func (k Keeper) SimulateV1(c context.Context, req *types.SimulateV1Request) (*ty
 		}
 		return &types.SimulateV1Response{
 			ErrorMessage: err.Error(),
-			ErrorCode:    int32(errCode), //nolint:gosec // errCode is an HTTP-style error code, bounded well within int32 range
+			ErrorCode:    int32(errCode),
 		}, nil
 	}
 

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -911,7 +911,7 @@ func (k Keeper) SimulateV1(c context.Context, req *types.SimulateV1Request) (*ty
 		}
 		return &types.SimulateV1Response{
 			ErrorMessage: err.Error(),
-			ErrorCode:    int32(errCode),
+			ErrorCode:    int32(errCode), //nolint:gosec // G115: error codes are small constants, overflow not possible
 		}, nil
 	}
 

--- a/x/evm/keeper/simulate.go
+++ b/x/evm/keeper/simulate.go
@@ -200,7 +200,7 @@ func (sim *Simulator) processBlock(
 		transactions[i] = tx
 		senders[txHash] = call.GetFrom()
 
-		tracer.Reset(txHash, uint(i))
+		tracer.Reset(txHash, uint(i)) //nolint:gosec // G115: i is a range index over block.Calls, always non-negative
 
 		msg, err := call.ToSimMessage(header.BaseFee, !sim.validate)
 		if err != nil {

--- a/x/evm/keeper/simulate.go
+++ b/x/evm/keeper/simulate.go
@@ -200,7 +200,7 @@ func (sim *Simulator) processBlock(
 		transactions[i] = tx
 		senders[txHash] = call.GetFrom()
 
-		tracer.Reset(txHash, uint(i)) //nolint:gosec // G115: i is a range index over block.Calls, always non-negative.
+		tracer.Reset(txHash, uint(i))
 
 		msg, err := call.ToSimMessage(header.BaseFee, !sim.validate)
 		if err != nil {

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -404,7 +404,6 @@ func (k *Keeper) ApplyMessageWithConfig(
 			}
 			tracingStateDB.SetNonce(sender, stateDB.GetNonce(sender)+1, tracing.NonceChangeEoACall)
 		}
-
 	}
 
 	rules := cfg.Rules

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -575,7 +575,8 @@ func (k *Keeper) ApplyMessageWithConfig(
 	leftoverGas = msg.GasLimit - gasUsed
 
 	if cfg.DebugTrace {
-		if err := k.RefundGas(ctx, msg, leftoverGas, cfg.Params.EvmDenom); err != nil {
+		debugGasPrice := debugTraceGasPrice(msg, cfg.BaseFee)
+		if err := k.RefundGasWithPrice(ctx, msg, leftoverGas, debugGasPrice, cfg.Params.EvmDenom); err != nil {
 			return nil, errorsmod.Wrapf(err, "failed to refund leftover gas to sender %s", msg.From)
 		}
 		if tracer != nil && tracer.OnGasChange != nil {

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -574,7 +574,11 @@ func (k *Keeper) ApplyMessageWithConfig(
 
 	if cfg.DebugTrace {
 		if tracer != nil {
-			stateDB.AddBalance(sender, uint256.NewInt(1).Mul(uint256.MustFromBig(debugTraceGasPrice(msg, cfg.BaseFee)), uint256.NewInt(leftoverGas)), tracing.BalanceIncreaseGasReturn)
+			refund := uint256.NewInt(1).Mul(
+				uint256.MustFromBig(debugTraceGasPrice(msg, cfg.BaseFee)),
+				uint256.NewInt(leftoverGas),
+			)
+			stateDB.AddBalance(sender, refund, tracing.BalanceIncreaseGasReturn)
 		}
 	}
 

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -373,6 +373,12 @@ func (k *Keeper) ApplyMessageWithConfig(
 	tracer := cfg.GetTracer()
 
 	if tracer != nil {
+		defer func() {
+			if tracer.OnTxEnd != nil {
+				tracer.OnTxEnd(&ethtypes.Receipt{GasUsed: gasUsed}, err)
+			}
+		}()
+
 		if tracer.OnGasChange != nil {
 			tracer.OnGasChange(0, msg.GasLimit, tracing.GasChangeTxInitialBalance)
 		}
@@ -399,11 +405,6 @@ func (k *Keeper) ApplyMessageWithConfig(
 			tracingStateDB.SetNonce(sender, stateDB.GetNonce(sender)+1, tracing.NonceChangeEoACall)
 		}
 
-		defer func() {
-			if tracer.OnTxEnd != nil {
-				tracer.OnTxEnd(&ethtypes.Receipt{GasUsed: gasUsed}, err)
-			}
-		}()
 	}
 
 	rules := cfg.Rules

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -372,17 +372,6 @@ func (k *Keeper) ApplyMessageWithConfig(
 	sender := msg.From
 	tracer := cfg.GetTracer()
 
-	if cfg.DebugTrace {
-		feeAmt := debugTraceFeeAmount(msg, cfg.BaseFee)
-		if feeAmt.Sign() > 0 {
-			fees := sdk.Coins{{Denom: cfg.Params.EvmDenom, Amount: sdkmath.NewIntFromBigInt(feeAmt)}}
-			if err := k.DeductTxCostsFromUserBalance(ctx, fees, msg.From); err != nil {
-				return nil, err
-			}
-		}
-		tracingStateDB.SetNonce(sender, stateDB.GetNonce(sender)+1, tracing.NonceChangeEoACall)
-	}
-
 	if tracer != nil {
 		if tracer.OnGasChange != nil {
 			tracer.OnGasChange(0, msg.GasLimit, tracing.GasChangeTxInitialBalance)
@@ -399,6 +388,15 @@ func (k *Keeper) ApplyMessageWithConfig(
 				}),
 				msg.From,
 			)
+		}
+
+		if cfg.DebugTrace {
+			feeAmt := debugTraceFeeAmount(msg, cfg.BaseFee)
+			stateDB.SubBalance(sender, uint256.MustFromBig(feeAmt), tracing.BalanceDecreaseGasBuy)
+			if err := stateDB.Error(); err != nil {
+				return nil, err
+			}
+			tracingStateDB.SetNonce(sender, stateDB.GetNonce(sender)+1, tracing.NonceChangeEoACall)
 		}
 
 		defer func() {
@@ -575,12 +573,8 @@ func (k *Keeper) ApplyMessageWithConfig(
 	leftoverGas = msg.GasLimit - gasUsed
 
 	if cfg.DebugTrace {
-		debugGasPrice := debugTraceGasPrice(msg, cfg.BaseFee)
-		if err := k.RefundGasWithPrice(ctx, msg, leftoverGas, debugGasPrice, cfg.Params.EvmDenom); err != nil {
-			return nil, errorsmod.Wrapf(err, "failed to refund leftover gas to sender %s", msg.From)
-		}
-		if tracer != nil && tracer.OnGasChange != nil {
-			tracer.OnGasChange(leftoverGas, 0, tracing.GasChangeTxLeftOverReturned)
+		if tracer != nil {
+			stateDB.AddBalance(sender, uint256.NewInt(1).Mul(uint256.MustFromBig(debugTraceGasPrice(msg, cfg.BaseFee)), uint256.NewInt(leftoverGas)), tracing.BalanceIncreaseGasReturn)
 		}
 	}
 

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -18,7 +18,6 @@ package keeper
 import (
 	"errors"
 	"fmt"
-	"math/big"
 
 	cmttypes "github.com/cometbft/cometbft/types"
 
@@ -334,8 +333,8 @@ func (k *Keeper) ApplyMessage(ctx sdk.Context, msg *core.Message, tracer *tracin
 // # debugTrace parameter
 //
 // The message is applied with steps to mimic AnteHandler
-//  1. the sender is consumed with gasLimit * gasPrice in full at the beginning of the execution and
-//     then refund with unused gas after execution.
+//  1. deduct gasLimit * gasPrice (effective gas price) through the fee collector, then refund unused
+//     gas after execution — same path as CheckEthGasConsume and ApplyTransaction.
 //  2. sender nonce is incremented by 1 before execution
 func (k *Keeper) ApplyMessageWithConfig(
 	ctx sdk.Context,
@@ -372,11 +371,18 @@ func (k *Keeper) ApplyMessageWithConfig(
 	leftoverGas := msg.GasLimit
 	sender := msg.From
 	tracer := cfg.GetTracer()
-	debugFn := func() {
-		if tracer != nil && cfg.DebugTrace {
-			stateDB.AddBalance(sender, uint256.NewInt(1).Mul(uint256.MustFromBig(msg.GasPrice), uint256.NewInt(leftoverGas)), tracing.BalanceIncreaseGasReturn)
+
+	if cfg.DebugTrace {
+		feeAmt := debugTraceFeeAmount(msg, cfg.BaseFee)
+		if feeAmt.Sign() > 0 {
+			fees := sdk.Coins{{Denom: cfg.Params.EvmDenom, Amount: sdkmath.NewIntFromBigInt(feeAmt)}}
+			if err := k.DeductTxCostsFromUserBalance(ctx, fees, msg.From); err != nil {
+				return nil, err
+			}
 		}
+		tracingStateDB.SetNonce(sender, stateDB.GetNonce(sender)+1, tracing.NonceChangeEoACall)
 	}
+
 	if tracer != nil {
 		if tracer.OnGasChange != nil {
 			tracer.OnGasChange(0, msg.GasLimit, tracing.GasChangeTxInitialBalance)
@@ -396,20 +402,10 @@ func (k *Keeper) ApplyMessageWithConfig(
 		}
 
 		defer func() {
-			debugFn()
 			if tracer.OnTxEnd != nil {
 				tracer.OnTxEnd(&ethtypes.Receipt{GasUsed: gasUsed}, err)
 			}
 		}()
-
-		if cfg.DebugTrace {
-			amount := new(big.Int).Mul(msg.GasPrice, new(big.Int).SetUint64(msg.GasLimit))
-			stateDB.SubBalance(sender, uint256.MustFromBig(amount), tracing.BalanceDecreaseGasBuy)
-			if err := stateDB.Error(); err != nil {
-				return nil, err
-			}
-			tracingStateDB.SetNonce(sender, stateDB.GetNonce(sender)+1, tracing.NonceChangeEoACall)
-		}
 	}
 
 	rules := cfg.Rules
@@ -578,8 +574,14 @@ func (k *Keeper) ApplyMessageWithConfig(
 	// reset leftoverGas, to be used by the tracer
 	leftoverGas = msg.GasLimit - gasUsed
 
-	debugFn()
-	debugFn = func() {}
+	if cfg.DebugTrace {
+		if err := k.RefundGas(ctx, msg, leftoverGas, cfg.Params.EvmDenom); err != nil {
+			return nil, errorsmod.Wrapf(err, "failed to refund leftover gas to sender %s", msg.From)
+		}
+		if tracer != nil && tracer.OnGasChange != nil {
+			tracer.OnGasChange(leftoverGas, 0, tracing.GasChangeTxLeftOverReturned)
+		}
+	}
 
 	// The dirty states in `StateDB` is either committed or discarded after return
 	if commit {

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -692,7 +692,6 @@ func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig_DebugTraceFee(
 		Value:            big.NewInt(0),
 		Data:             nil,
 		SkipNonceChecks:  false,
-		SkipFromEOACheck: false,
 	}
 
 	cfg, err := suite.App.EvmKeeper.EVMConfig(suite.Ctx, suite.App.EvmKeeper.ChainID(), common.Hash{})

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
-	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 	cmtcrypto "github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtrand "github.com/cometbft/cometbft/libs/rand"
@@ -18,6 +17,7 @@ import (
 	tmtypes "github.com/cometbft/cometbft/types"
 	"github.com/cometbft/cometbft/version"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -682,16 +682,16 @@ func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig_DebugTraceFee(
 
 	to := common.BigToAddress(big.NewInt(1))
 	msg := &core.Message{
-		From:             suite.Address,
-		To:               &to,
-		Nonce:            suite.App.EvmKeeper.GetNonce(suite.Ctx, suite.Address),
-		GasLimit:         gasLimit,
-		GasPrice:         gasFeeCap, // fee cap, not effective price
-		GasFeeCap:        gasFeeCap,
-		GasTipCap:        gasTipCap,
-		Value:            big.NewInt(0),
-		Data:             nil,
-		SkipNonceChecks:  false,
+		From:            suite.Address,
+		To:              &to,
+		Nonce:           suite.App.EvmKeeper.GetNonce(suite.Ctx, suite.Address),
+		GasLimit:        gasLimit,
+		GasPrice:        gasFeeCap, // fee cap, not effective price
+		GasFeeCap:       gasFeeCap,
+		GasTipCap:       gasTipCap,
+		Value:           big.NewInt(0),
+		Data:            nil,
+		SkipNonceChecks: false,
 	}
 
 	cfg, err := suite.App.EvmKeeper.EVMConfig(suite.Ctx, suite.App.EvmKeeper.ChainID(), common.Hash{})
@@ -700,12 +700,24 @@ func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig_DebugTraceFee(
 	cfg.DebugTrace = true
 	cfg.TxConfig = suite.App.EvmKeeper.TxConfig(suite.Ctx, common.Hash{})
 
+	// The up-front gas-buy during debug tracing must charge the effective fee,
+	// min(gasTipCap + baseFee, gasFeeCap) * gasLimit, rather than the fee cap * gas.
+	// Funding the sender with exactly the effective fee proves both bounds: the
+	// charge cannot exceed it (the call would fail on insufficient balance, which
+	// is what charging fee cap * gas would do here), and funding one unit less
+	// proves the charge is not below it either.
 	suite.Require().NoError(
 		suite.App.EvmKeeper.SetBalance(suite.Ctx, suite.Address, *uint256.MustFromBig(effectiveFee), types.DefaultEVMDenom),
 	)
-
 	_, err = suite.App.EvmKeeper.ApplyMessageWithConfig(suite.Ctx, msg, cfg, false)
 	suite.Require().NoError(err, "debug trace must deduct effective fee, not fee cap * gas")
+
+	oneLess := new(big.Int).Sub(effectiveFee, big.NewInt(1))
+	suite.Require().NoError(
+		suite.App.EvmKeeper.SetBalance(suite.Ctx, suite.Address, *uint256.MustFromBig(oneLess), types.DefaultEVMDenom),
+	)
+	_, err = suite.App.EvmKeeper.ApplyMessageWithConfig(suite.Ctx, msg, cfg, false)
+	suite.Require().Error(err, "debug trace must charge the full effective fee")
 }
 
 func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig() {

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -661,6 +661,54 @@ func (suite *StateTransitionTestSuite) TestApplyMessage() {
 	suite.Require().False(res.Failed())
 }
 
+func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig_DebugTraceFee() {
+	t := suite.T()
+	suite.SetupTestWithCb(t, func(a *evmd.EthermintApp, genesis evmd.GenesisState) evmd.GenesisState {
+		feemarketGenesis := feemarkettypes.DefaultGenesisState()
+		feemarketGenesis.Params.EnableHeight = 1
+		feemarketGenesis.Params.NoBaseFee = false
+		genesis[feemarkettypes.ModuleName] = a.AppCodec().MustMarshalJSON(feemarketGenesis)
+		return genesis
+	})
+	suite.mintFeeCollector = true
+	suite.SetupTest()
+
+	baseFee := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(0)
+	gasFeeCap := big.NewInt(5_000_000_000_000)
+	gasLimit := uint64(2_000_000)
+	effectiveGas := new(big.Int).Add(gasTipCap, baseFee)
+	effectiveFee := new(big.Int).Mul(effectiveGas, new(big.Int).SetUint64(gasLimit))
+
+	to := common.BigToAddress(big.NewInt(1))
+	msg := &core.Message{
+		From:             suite.Address,
+		To:               &to,
+		Nonce:            suite.App.EvmKeeper.GetNonce(suite.Ctx, suite.Address),
+		GasLimit:         gasLimit,
+		GasPrice:         gasFeeCap, // fee cap, not effective price
+		GasFeeCap:        gasFeeCap,
+		GasTipCap:        gasTipCap,
+		Value:            big.NewInt(0),
+		Data:             nil,
+		SkipNonceChecks:  false,
+		SkipFromEOACheck: false,
+	}
+
+	cfg, err := suite.App.EvmKeeper.EVMConfig(suite.Ctx, suite.App.EvmKeeper.ChainID(), common.Hash{})
+	suite.Require().NoError(err)
+	cfg.BaseFee = baseFee
+	cfg.DebugTrace = true
+	cfg.TxConfig = suite.App.EvmKeeper.TxConfig(suite.Ctx, common.Hash{})
+
+	suite.Require().NoError(
+		suite.App.EvmKeeper.SetBalance(suite.Ctx, suite.Address, *uint256.MustFromBig(effectiveFee), types.DefaultEVMDenom),
+	)
+
+	_, err = suite.App.EvmKeeper.ApplyMessageWithConfig(suite.Ctx, msg, cfg, false)
+	suite.Require().NoError(err, "debug trace must deduct effective fee, not fee cap * gas")
+}
+
 func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig() {
 	var (
 		msg             *core.Message

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -697,8 +697,21 @@ func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig_DebugTraceFee(
 	cfg, err := suite.App.EvmKeeper.EVMConfig(suite.Ctx, suite.App.EvmKeeper.ChainID(), common.Hash{})
 	suite.Require().NoError(err)
 	cfg.BaseFee = baseFee
-	cfg.DebugTrace = true
 	cfg.TxConfig = suite.App.EvmKeeper.TxConfig(suite.Ctx, common.Hash{})
+
+	var txStarts, txEnds, gasChanges int
+	cfg.Tracer = &tracing.Hooks{
+		OnTxStart: func(*tracing.VMContext, *ethtypes.Transaction, common.Address) {
+			txStarts++
+		},
+		OnTxEnd: func(*ethtypes.Receipt, error) {
+			txEnds++
+		},
+		OnGasChange: func(_, _ uint64, _ tracing.GasChangeReason) {
+			gasChanges++
+		},
+	}
+	cfg.DebugTrace = true
 
 	// The up-front gas-buy during debug tracing must charge the effective fee,
 	// min(gasTipCap + baseFee, gasFeeCap) * gasLimit, rather than the fee cap * gas.
@@ -711,6 +724,10 @@ func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig_DebugTraceFee(
 	)
 	_, err = suite.App.EvmKeeper.ApplyMessageWithConfig(suite.Ctx, msg, cfg, false)
 	suite.Require().NoError(err, "debug trace must deduct effective fee, not fee cap * gas")
+	suite.Require().Equal(1, txStarts, "tracer must observe tx start")
+	suite.Require().Equal(1, txEnds, "tracer must observe tx end")
+	suite.Require().Greater(gasChanges, 1, "tracer must observe gas changes through execution")
+	gasChangesAfterSuccess := gasChanges
 
 	oneLess := new(big.Int).Sub(effectiveFee, big.NewInt(1))
 	suite.Require().NoError(
@@ -718,6 +735,13 @@ func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig_DebugTraceFee(
 	)
 	_, err = suite.App.EvmKeeper.ApplyMessageWithConfig(suite.Ctx, msg, cfg, false)
 	suite.Require().Error(err, "debug trace must charge the full effective fee")
+	suite.Require().Equal(2, txStarts, "tracer must run on insufficient-balance debug trace attempt")
+	suite.Require().Equal(2, txEnds, "tracer must end tx even when up-front gas buy fails")
+	suite.Require().Equal(
+		gasChangesAfterSuccess+1,
+		gasChanges,
+		"failed attempt should only record the initial gas snapshot before the up-front gas buy fails",
+	)
 }
 
 func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig() {

--- a/x/evm/keeper/utils.go
+++ b/x/evm/keeper/utils.go
@@ -35,13 +35,23 @@ import (
 	"github.com/evmos/ethermint/x/evm/types"
 )
 
-// debugTraceFeeAmount returns the gas fee charged up front during debug tracing.
-// It matches the ante handler: effective gas price multiplied by gas limit.
-func debugTraceFeeAmount(msg *core.Message, baseFee *big.Int) *big.Int {
-	gasPrice := new(big.Int).Set(msg.GasPrice)
+// debugTraceGasPrice returns the effective gas price used by debug tracing.
+// It follows the same effective-price rule as ante handling.
+func debugTraceGasPrice(msg *core.Message, baseFee *big.Int) *big.Int {
+	gasPrice := new(big.Int)
+	if msg.GasPrice != nil {
+		gasPrice.Set(msg.GasPrice)
+	}
 	if baseFee != nil && msg.GasFeeCap != nil && msg.GasTipCap != nil {
 		gasPrice = ethermint.BigMin(new(big.Int).Add(msg.GasTipCap, baseFee), msg.GasFeeCap)
 	}
+	return gasPrice
+}
+
+// debugTraceFeeAmount returns the gas fee charged up front during debug tracing.
+// It matches the ante handler: effective gas price multiplied by gas limit.
+func debugTraceFeeAmount(msg *core.Message, baseFee *big.Int) *big.Int {
+	gasPrice := debugTraceGasPrice(msg, baseFee)
 	return new(big.Int).Mul(gasPrice, new(big.Int).SetUint64(msg.GasLimit))
 }
 

--- a/x/evm/keeper/utils.go
+++ b/x/evm/keeper/utils.go
@@ -31,8 +31,19 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
+	ethermint "github.com/evmos/ethermint/types"
 	"github.com/evmos/ethermint/x/evm/types"
 )
+
+// debugTraceFeeAmount returns the gas fee charged up front during debug tracing.
+// It matches the ante handler: effective gas price multiplied by gas limit.
+func debugTraceFeeAmount(msg *core.Message, baseFee *big.Int) *big.Int {
+	gasPrice := new(big.Int).Set(msg.GasPrice)
+	if baseFee != nil && msg.GasFeeCap != nil && msg.GasTipCap != nil {
+		gasPrice = ethermint.BigMin(new(big.Int).Add(msg.GasTipCap, baseFee), msg.GasFeeCap)
+	}
+	return new(big.Int).Mul(gasPrice, new(big.Int).SetUint64(msg.GasLimit))
+}
 
 // GetCoinbaseAddress returns the block proposer's validator operator address.
 func (k Keeper) GetCoinbaseAddress(ctx sdk.Context) (common.Address, error) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

  The issue is that debug_traceTransaction was computing the upfront gas fee as gasLimit × gasPrice (the raw field),
  which for EIP-1559 txs can be much higher than what was actually charged on-chain. 

  The fix computes the correct effective gas price (min(baseFee + gasTipCap, gasFeeCap)) — matching what geth's state
  transition actually charges — and performs the deduction at the EVM stateDB level rather than going through the bank
  module's spendable balance check. This means the trace will always succeed as long as the original tx succeeded
  on-chain.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
