### PR TITLE
fix: setting evm hooks prevent the stateDB from committing for failed tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (test) [#926](https://github.com/crypto-org-chain/ethermint/pull/926) fix(test): remove flaky `base_fee` assertion in `update_feemarket_param`.
 * (server) [#946](https://github.com/crypto-org-chain/ethermint/pull/946) feat(server): make JSON-RPC batch limits configurable.
 * (geth) [#957](https://github.com/crypto-org-chain/ethermint/pull/957) feat(geth): update go-ethereum version to `v1.16.9`, enable Osaka hardfork
-* (evm) [#](https://github.com/crypto-org-chain/ethermint/pull/) fix: setting evm hooks prevent the stateDB from committing for failed tx
+* (evm) [#973](https://github.com/crypto-org-chain/ethermint/pull/973) fix: setting evm hooks prevent the stateDB from committing for failed tx
 
 
 ## [v0.23.0] - 2026-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (geth) [#957](https://github.com/crypto-org-chain/ethermint/pull/957) feat(geth): update go-ethereum version to `v1.16.9`, enable Osaka hardfork
 * (evm) [#973](https://github.com/crypto-org-chain/ethermint/pull/973) fix: setting evm hooks prevent the stateDB from committing for failed tx
 
-
 ## [v0.23.0] - 2026-01-13
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (test) [#926](https://github.com/crypto-org-chain/ethermint/pull/926) fix(test): remove flaky `base_fee` assertion in `update_feemarket_param`.
 * (server) [#946](https://github.com/crypto-org-chain/ethermint/pull/946) feat(server): make JSON-RPC batch limits configurable.
 * (geth) [#957](https://github.com/crypto-org-chain/ethermint/pull/957) feat(geth): update go-ethereum version to `v1.16.9`, enable Osaka hardfork
+* (evm) [#](https://github.com/crypto-org-chain/ethermint/pull/) fix: setting evm hooks prevent the stateDB from committing for failed tx
+
 
 ## [v0.23.0] - 2026-01-13
 

--- a/go.mod
+++ b/go.mod
@@ -377,6 +377,9 @@ require (
 replace (
 	// use cosmos keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
+
+	// release/v0.54.x
+	github.com/cosmos/cosmos-sdk => github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20260601063535-2cd50b219979
 	// release/v1.16
 	github.com/ethereum/go-ethereum => github.com/crypto-org-chain/go-ethereum v1.10.20-0.20260521015249-663dca6c618e
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,6 @@ github.com/cosmos/cosmos-db v1.1.3 h1:7QNT77+vkefostcKkhrzDK9uoIEryzFrU9eoMeaQOP
 github.com/cosmos/cosmos-db v1.1.3/go.mod h1:kN+wGsnwUJZYn8Sy5Q2O0vCYA99MJllkKASbs6Unb9U=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.54.3 h1:oUxbIACmHZV13IZXl59y+mIEOCFlUAjXV9p1rqrYcEg=
-github.com/cosmos/cosmos-sdk v0.54.3/go.mod h1:Unt21RO+q1EebU6gcUPKYVzpAQSr4KIHjaOmjpz2twA=
 github.com/cosmos/cosmos-sdk/store/v2 v2.0.0 h1:5CFXBU5cHIvxMpz5QBrTwR5DL/W3uZL2BYYMoDp4siY=
 github.com/cosmos/cosmos-sdk/store/v2 v2.0.0/go.mod h1:XyRyi5fGjIcokBqS1cyA8/QVbVNy4ui8hmpk1gezuHo=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
@@ -305,6 +303,8 @@ github.com/creachadair/tomledit v0.0.29 h1:dB5CbdwJMpn/fmfAPTAAleXF/KJwY0Ggc1eL/
 github.com/creachadair/tomledit v0.0.29/go.mod h1:4SoTXxzHgvzHRMIJPw+o6zK/yXii4VjLrb6/3gCQnyA=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20260601063535-2cd50b219979 h1:s39a1MkV0ViXNiiXQm8DC2iNFbErjAbPA0GPMkGaH54=
+github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20260601063535-2cd50b219979/go.mod h1:Unt21RO+q1EebU6gcUPKYVzpAQSr4KIHjaOmjpz2twA=
 github.com/crypto-org-chain/go-ethereum v1.10.20-0.20260521015249-663dca6c618e h1:ftyRRWDiXKWsnp3PxLNbfVLzrqkx+aDNZdkPconawWk=
 github.com/crypto-org-chain/go-ethereum v1.10.20-0.20260521015249-663dca6c618e/go.mod h1:Fs6QebQbavneQTYcA39PEKv2+zIjX7rPUZ14DER46wk=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -249,8 +249,9 @@ schema = 3
     version = "v1.0.0-beta.5"
     hash = "sha256-Fy/PbsOsd6iq0Njy3DVWK6HqWsogI+MkE8QslHGWyVg="
   [mod."github.com/cosmos/cosmos-sdk"]
-    version = "v0.54.3"
-    hash = "sha256-PXDd2CQzJW/UecsfApDF6A8fqy6QZtSQzwqTErlK1mk="
+    version = "v0.50.6-0.20260601063535-2cd50b219979"
+    hash = "sha256-rjhqJVu4Oh9Er4HfwHAdi1LNqoTEuHmqkRfLMXKYMh0="
+    replaced = "github.com/crypto-org-chain/cosmos-sdk"
   [mod."github.com/cosmos/cosmos-sdk/store/v2"]
     version = "v2.0.0"
     hash = "sha256-UlKTyyx31e9sd7TH4fH3HlEle92anUoezZm94YQ7r6M="

--- a/x/evm/keeper/config.go
+++ b/x/evm/keeper/config.go
@@ -63,6 +63,9 @@ type EVMConfig struct {
 	DebugTrace     bool
 	Overrides      *rpctypes.StateOverride
 	BlockOverrides *rpctypes.BlockOverrides
+	// DurableSetCodeAuthorizationCtx persists valid EIP-7702 authorization effects
+	// (authority nonce + code) even if the hook CacheContext is later discarded.
+	DurableSetCodeAuthorizationCtx *sdk.Context
 }
 
 // EVMBlockConfig creates the EVMBlockConfig based on current state

--- a/x/evm/keeper/set_code_authorizations.go
+++ b/x/evm/keeper/set_code_authorizations.go
@@ -44,6 +44,14 @@ func (k *Keeper) validateAuthorization(auth *types.SetCodeAuthorization, stateDB
 
 // applyAuthorization applies an EIP-7702 code delegation to the state.
 func (k *Keeper) applyAuthorization(auth *types.SetCodeAuthorization, stateDB vm.StateDB) error {
+	return k.applyAuthorizationWithRefund(auth, stateDB, true)
+}
+
+func (k *Keeper) applyDurableAuthorization(auth *types.SetCodeAuthorization, stateDB vm.StateDB) error {
+	return k.applyAuthorizationWithRefund(auth, stateDB, false)
+}
+
+func (k *Keeper) applyAuthorizationWithRefund(auth *types.SetCodeAuthorization, stateDB vm.StateDB, addRefund bool) error {
 	authority, err := k.validateAuthorization(auth, stateDB)
 	if err != nil {
 		return err
@@ -51,7 +59,7 @@ func (k *Keeper) applyAuthorization(auth *types.SetCodeAuthorization, stateDB vm
 
 	// If the account already exists in state, refund the new account cost
 	// charged in the intrinsic calculation.
-	if stateDB.Exist(authority) {
+	if addRefund && stateDB.Exist(authority) {
 		stateDB.AddRefund(params.CallNewAccountGas - params.TxAuthTupleGas)
 	}
 

--- a/x/evm/keeper/set_code_authorizations.go
+++ b/x/evm/keeper/set_code_authorizations.go
@@ -42,37 +42,44 @@ func (k *Keeper) validateAuthorization(auth *types.SetCodeAuthorization, stateDB
 	return authority, nil
 }
 
-// applyAuthorization applies an EIP-7702 code delegation to the state.
-func (k *Keeper) applyAuthorization(auth *types.SetCodeAuthorization, stateDB vm.StateDB) error {
-	return k.applyAuthorizationWithRefund(auth, stateDB, true)
-}
-
-func (k *Keeper) applyDurableAuthorization(auth *types.SetCodeAuthorization, stateDB vm.StateDB) error {
-	return k.applyAuthorizationWithRefund(auth, stateDB, false)
-}
-
-func (k *Keeper) applyAuthorizationWithRefund(auth *types.SetCodeAuthorization, stateDB vm.StateDB, addRefund bool) error {
+// applyAuthorization validates and applies an EIP-7702 code delegation to the
+// state, returning the recovered authority so callers can reuse it without a
+// second (expensive) signature recovery.
+func (k *Keeper) applyAuthorization(auth *types.SetCodeAuthorization, stateDB vm.StateDB) (common.Address, error) {
 	authority, err := k.validateAuthorization(auth, stateDB)
 	if err != nil {
-		return err
+		return authority, err
 	}
 
 	// If the account already exists in state, refund the new account cost
 	// charged in the intrinsic calculation.
-	if addRefund && stateDB.Exist(authority) {
+	if stateDB.Exist(authority) {
 		stateDB.AddRefund(params.CallNewAccountGas - params.TxAuthTupleGas)
 	}
 
+	k.setAuthorizationDelegation(auth, authority, stateDB)
+	return authority, nil
+}
+
+// applyDurableAuthorization replays the delegation effects of an
+// already-validated authorization onto the durable stateDB. The authority was
+// recovered by applyAuthorization, so we skip re-validation (no ecrecover) and
+// the refund (which only matters for the EVM gas accounting on the main path).
+func (k *Keeper) applyDurableAuthorization(auth *types.SetCodeAuthorization, authority common.Address, stateDB vm.StateDB) {
+	k.setAuthorizationDelegation(auth, authority, stateDB)
+}
+
+// setAuthorizationDelegation writes the nonce bump and delegation code for a
+// validated authorization.
+func (k *Keeper) setAuthorizationDelegation(auth *types.SetCodeAuthorization, authority common.Address, stateDB vm.StateDB) {
 	// Update nonce and account code.
 	stateDB.SetNonce(authority, auth.Nonce+1, tracing.NonceChangeAuthorization)
 	if auth.Address == (common.Address{}) {
 		// Delegation to zero address means clear.
 		stateDB.SetCode(authority, nil, tracing.CodeChangeAuthorizationClear)
-		return nil
+		return
 	}
 
 	// Otherwise install delegation to auth.Address.
 	stateDB.SetCode(authority, types.AddressToDelegation(auth.Address), tracing.CodeChangeAuthorization)
-
-	return nil
 }

--- a/x/evm/keeper/simulate.go
+++ b/x/evm/keeper/simulate.go
@@ -401,7 +401,7 @@ func (sim *Simulator) applyCall(
 	} else {
 		if msg.SetCodeAuthorizations != nil {
 			for _, auth := range msg.SetCodeAuthorizations {
-				if err := sim.keeper.applyAuthorization(&auth, sim.state); err != nil {
+				if _, err := sim.keeper.applyAuthorization(&auth, sim.state); err != nil {
 					sim.keeper.Logger(sim.state.Context()).Debug("simulation: failed to apply authorization",
 						"error", err, "authorization", auth)
 				}

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -178,6 +178,8 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 		// Didn't use `Snapshot` because the context stack has exponential complexity on certain operations,
 		// thus restricted to be used only inside `ApplyMessage`.
 		tmpCtx, commit = ctx.CacheContext()
+
+		cfg.DurableSetCodeAuthorizationCtx = &ctx
 	}
 
 	// pass true to commit the StateDB
@@ -456,10 +458,25 @@ func (k *Keeper) ApplyMessageWithConfig(
 		stateDB.SetNonce(sender, oldNonce+nestedCreates, tracing.NonceChangeUnspecified)
 	} else {
 		if msg.SetCodeAuthorizations != nil {
+			var validAuths []ethtypes.SetCodeAuthorization
 			for _, auth := range msg.SetCodeAuthorizations {
 				// Note errors are ignored, we simply skip invalid authorizations here.
 				if err := k.applyAuthorization(&auth, stateDB); err != nil {
 					k.Logger(ctx).Debug("failed to apply authorization", "error", err, "authorization", auth)
+					continue
+				}
+				validAuths = append(validAuths, auth)
+			}
+
+			if commit && cfg.DurableSetCodeAuthorizationCtx != nil && len(validAuths) > 0 {
+				durableStateDB := statedb.NewWithParams(*cfg.DurableSetCodeAuthorizationCtx, k, cfg.TxConfig, cfg.Params.EvmDenom)
+				for _, auth := range validAuths {
+					if err := k.applyAuthorization(&auth, durableStateDB); err != nil {
+						return nil, errorsmod.Wrap(err, "failed to apply durable EIP-7702 authorization")
+					}
+				}
+				if err := durableStateDB.Commit(); err != nil {
+					return nil, errorsmod.Wrap(err, "failed to commit durable EIP-7702 authorization stateDB")
 				}
 			}
 		}

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -493,7 +493,7 @@ func (k *Keeper) ApplyMessageWithConfig(
 				durableStateDB := statedb.NewWithParams(*cfg.DurableSetCodeAuthorizationCtx, k, cfg.TxConfig, cfg.Params.EvmDenom)
 				for _, va := range validAuths {
 					// Replay the already-validated effects; this cannot fail, so it
-					// mirrors the main loop's skip-on-invalid behaviour without ever
+					// mirrors the main loop's skip-on-invalid behavior without ever
 					// turning an EVM-level outcome into a cosmos-level tx error.
 					k.applyDurableAuthorization(&va.auth, va.authority, durableStateDB)
 				}

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -181,11 +181,14 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 		// thus restricted to be used only inside `ApplyMessage`.
 		tmpCtx, commit = ctx.CacheContext()
 
-		// Keep the EIP-7702 authorization effects in a separate cache.
-		// They should survive EVM/post-hook failures,
-		durableAuthorizationCtx, commitDurableAuthorizationCache := ctx.CacheContext()
-		cfg.DurableSetCodeAuthorizationCtx = &durableAuthorizationCtx
-		commitDurableAuthorization = commitDurableAuthorizationCache
+		// Keep the EIP-7702 authorization effects in a separate cache so they
+		// survive a later EVM/post-hook failure that discards tmpCtx. Only needed
+		// for txs that actually carry authorizations.
+		if len(msg.SetCodeAuthorizations) > 0 {
+			var durableAuthorizationCtx sdk.Context
+			durableAuthorizationCtx, commitDurableAuthorization = ctx.CacheContext()
+			cfg.DurableSetCodeAuthorizationCtx = &durableAuthorizationCtx
+		}
 	}
 
 	// pass true to commit the StateDB
@@ -469,22 +472,30 @@ func (k *Keeper) ApplyMessageWithConfig(
 		stateDB.SetNonce(sender, oldNonce+nestedCreates, tracing.NonceChangeUnspecified)
 	} else {
 		if msg.SetCodeAuthorizations != nil {
-			var validAuths []ethtypes.SetCodeAuthorization
+			// Track validated authorizations together with the authority recovered
+			// during validation, so the durable replay below can reuse it.
+			type validAuth struct {
+				auth      ethtypes.SetCodeAuthorization
+				authority common.Address
+			}
+			var validAuths []validAuth
 			for _, auth := range msg.SetCodeAuthorizations {
 				// Note errors are ignored, we simply skip invalid authorizations here.
-				if err := k.applyAuthorization(&auth, stateDB); err != nil {
+				authority, err := k.applyAuthorization(&auth, stateDB)
+				if err != nil {
 					k.Logger(ctx).Debug("failed to apply authorization", "error", err, "authorization", auth)
 					continue
 				}
-				validAuths = append(validAuths, auth)
+				validAuths = append(validAuths, validAuth{auth: auth, authority: authority})
 			}
 
 			if commit && cfg.DurableSetCodeAuthorizationCtx != nil && len(validAuths) > 0 {
 				durableStateDB := statedb.NewWithParams(*cfg.DurableSetCodeAuthorizationCtx, k, cfg.TxConfig, cfg.Params.EvmDenom)
-				for _, auth := range validAuths {
-					if err := k.applyDurableAuthorization(&auth, durableStateDB); err != nil {
-						return nil, errorsmod.Wrap(err, "failed to apply durable EIP-7702 authorization")
-					}
+				for _, va := range validAuths {
+					// Replay the already-validated effects; this cannot fail, so it
+					// mirrors the main loop's skip-on-invalid behaviour without ever
+					// turning an EVM-level outcome into a cosmos-level tx error.
+					k.applyDurableAuthorization(&va.auth, va.authority, durableStateDB)
 				}
 				if err := durableStateDB.Commit(); err != nil {
 					return nil, errorsmod.Wrap(err, "failed to commit durable EIP-7702 authorization stateDB")

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -471,7 +471,7 @@ func (k *Keeper) ApplyMessageWithConfig(
 			if commit && cfg.DurableSetCodeAuthorizationCtx != nil && len(validAuths) > 0 {
 				durableStateDB := statedb.NewWithParams(*cfg.DurableSetCodeAuthorizationCtx, k, cfg.TxConfig, cfg.Params.EvmDenom)
 				for _, auth := range validAuths {
-					if err := k.applyAuthorization(&auth, durableStateDB); err != nil {
+					if err := k.applyDurableAuthorization(&auth, durableStateDB); err != nil {
 						return nil, errorsmod.Wrap(err, "failed to apply durable EIP-7702 authorization")
 					}
 				}

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -171,6 +171,8 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 	msg := msgEth.AsMessage(cfg.BaseFee)
 	// snapshot to contain the tx processing and post processing in same scope
 	var commit func()
+	var commitDurableAuthorization func()
+	tmpCtxCommitted := false
 	tmpCtx := ctx
 	if k.hooks != nil {
 		// Create a cache context to revert state when tx hooks fails,
@@ -179,7 +181,11 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 		// thus restricted to be used only inside `ApplyMessage`.
 		tmpCtx, commit = ctx.CacheContext()
 
-		cfg.DurableSetCodeAuthorizationCtx = &ctx
+		// Keep the EIP-7702 authorization effects in a separate cache.
+		// They should survive EVM/post-hook failures,
+		durableAuthorizationCtx, commitDurableAuthorizationCache := ctx.CacheContext()
+		cfg.DurableSetCodeAuthorizationCtx = &durableAuthorizationCtx
+		commitDurableAuthorization = commitDurableAuthorizationCache
 	}
 
 	// pass true to commit the StateDB
@@ -231,6 +237,7 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 		} else if commit != nil {
 			// PostTxProcessing is successful, commit the tmpCtx
 			commit()
+			tmpCtxCommitted = true
 			// Since the post-processing can alter the log, we need to update the result
 			res.Logs = types.NewLogsFromEth(receipt.Logs)
 		}
@@ -252,6 +259,10 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 	totalGasUsed, err := k.AddTransientGasUsed(ctx, res.GasUsed)
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "failed to add transient gas used")
+	}
+
+	if commitDurableAuthorization != nil && !tmpCtxCommitted {
+		commitDurableAuthorization()
 	}
 
 	// reset the gas meter for current cosmos transaction

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -826,6 +826,32 @@ func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationSurvivesPostHookF
 	suite.Require().Equal(common.Hash{}, storageValue, "posthook failure must still roll back ordinary EVM state")
 }
 
+func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationNotCommittedOnCosmosLevelError() {
+	suite.SetupTest()
+	suite.App.EvmKeeper.SetHooks(keeper.NewMultiEvmHooks(&LogRecordHook{}))
+
+	failingTarget := common.HexToAddress("0x0000000000000000000000000000000000007709")
+	delegate := common.HexToAddress("0x000000000000000000000000000000000000dE1E")
+	authorityKey, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+	authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+
+	vmdb := suite.StateDB()
+	vmdb.SetCode(failingTarget, []byte{0xfe}, 0)
+	suite.Require().NoError(vmdb.Commit())
+
+	suite.App.EvmKeeper.SetTransientGasUsed(suite.Ctx, math.MaxUint64)
+
+	msg := suite.buildSetCodeTx(failingTarget, authorityKey, delegate, 0, 100000)
+	_, err = suite.App.EvmKeeper.EthereumTx(suite.Ctx, msg)
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "failed to add transient gas used")
+
+	vmdb = suite.StateDB()
+	suite.Require().Zero(vmdb.GetNonce(authority))
+	suite.Require().Empty(vmdb.GetCode(authority))
+}
+
 func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationDurableCtxIgnoredWhenCommitFalse() {
 	suite.SetupTest()
 

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -888,7 +888,15 @@ func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationDurableReplayDoes
 	tmpCtx, commit := suite.Ctx.CacheContext()
 	cfg, err := suite.App.EvmKeeper.EVMConfig(tmpCtx, suite.App.EvmKeeper.ChainID(), common.Hash{})
 	suite.Require().NoError(err)
-	cfg.DurableSetCodeAuthorizationCtx = &suite.Ctx
+	// Mirror the production ApplyTransaction setup: the durable authorization
+	// context is a sibling cache branch of the parent ctx (not the parent
+	// itself), so the durable replay runs into an isolated store the main
+	// execution ctx cannot observe. Sharing the parent here would let the
+	// durable commit's account writes collide with the main statedb commit
+	// under the auth keeper's unique account-number index, since account
+	// numbers are now generated deterministically per address.
+	durableCtx, _ := suite.Ctx.CacheContext()
+	cfg.DurableSetCodeAuthorizationCtx = &durableCtx
 
 	var (
 		authorizationNonceChanges int

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -847,6 +848,55 @@ func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationDurableCtxIgnored
 	vmdb := suite.StateDB()
 	suite.Require().Zero(vmdb.GetNonce(authority))
 	suite.Require().Empty(vmdb.GetCode(authority))
+}
+
+func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationDurableReplayDoesNotEmitEthereumEvents() {
+	suite.SetupTest()
+
+	target := common.HexToAddress("0x0000000000000000000000000000000000007708")
+	delegate := common.HexToAddress("0x000000000000000000000000000000000000dE1E")
+	authorityKey, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+	authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+
+	tmpCtx, commit := suite.Ctx.CacheContext()
+	cfg, err := suite.App.EvmKeeper.EVMConfig(tmpCtx, suite.App.EvmKeeper.ChainID(), common.Hash{})
+	suite.Require().NoError(err)
+	cfg.DurableSetCodeAuthorizationCtx = &suite.Ctx
+
+	var (
+		authorizationNonceChanges int
+		authorizationCodeChanges  int
+		ethereumLogs              int
+	)
+	cfg.Tracer = &tracing.Hooks{
+		OnNonceChangeV2: func(addr common.Address, _, _ uint64, reason tracing.NonceChangeReason) {
+			if addr == authority && reason == tracing.NonceChangeAuthorization {
+				authorizationNonceChanges++
+			}
+		},
+		OnCodeChangeV2: func(addr common.Address, _ common.Hash, _ []byte, _ common.Hash, _ []byte, reason tracing.CodeChangeReason) {
+			if addr == authority && reason == tracing.CodeChangeAuthorization {
+				authorizationCodeChanges++
+			}
+		},
+		OnLog: func(*ethtypes.Log) {
+			ethereumLogs++
+		},
+	}
+
+	msgEth := suite.buildSetCodeTx(target, authorityKey, delegate, 0, 100000)
+	msg := msgEth.AsMessage(cfg.BaseFee)
+	res, err := suite.App.EvmKeeper.ApplyMessageWithConfig(tmpCtx, msg, cfg, true)
+	suite.Require().NoError(err)
+	suite.Require().False(res.Failed())
+	commit()
+
+	suite.Require().Zero(authorizationNonceChanges)
+	suite.Require().Zero(authorizationCodeChanges)
+	suite.Require().Zero(ethereumLogs)
+	suite.Require().Empty(res.Logs)
+	suite.requireSetCodeAuthorizationConsumed(authority, delegate, 1)
 }
 
 func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationReplayByDifferentOuterSignerSkippedAfterFailedExecution() {

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"fmt"
 	"math"
 	"math/big"
@@ -38,6 +39,7 @@ import (
 	"github.com/evmos/ethermint/x/evm/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	feemarkettypes "github.com/evmos/ethermint/x/feemarket/types"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -749,6 +751,295 @@ func (suite *StateTransitionTestSuite) TestApplyMessageWithConfig() {
 			suite.Require().Equal(expectedGasUsed, result.GasUsed)
 		})
 	}
+}
+
+func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationSurvivesFailedExecutionWithAndWithoutHooks() {
+	testCases := []struct {
+		name       string
+		setupHooks func()
+	}{
+		{
+			name: "no hooks",
+		},
+		{
+			name: "hooks enabled",
+			setupHooks: func() {
+				suite.App.EvmKeeper.SetHooks(keeper.NewMultiEvmHooks(&LogRecordHook{}))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+			if tc.setupHooks != nil {
+				tc.setupHooks()
+			}
+
+			failingTarget := common.HexToAddress("0x0000000000000000000000000000000000007702")
+			delegate := common.HexToAddress("0x000000000000000000000000000000000000dE1E")
+			authorityKey, err := crypto.GenerateKey()
+			suite.Require().NoError(err)
+			authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+
+			vmdb := suite.StateDB()
+			vmdb.SetCode(failingTarget, []byte{0xfe}, 0)
+			suite.Require().NoError(vmdb.Commit())
+
+			msg := suite.buildSetCodeTx(failingTarget, authorityKey, delegate, 0, 100000)
+			res, err := suite.App.EvmKeeper.EthereumTx(suite.Ctx, msg)
+			suite.Require().NoError(err)
+			suite.Require().True(res.Failed())
+			suite.Require().NotEmpty(res.VmError)
+
+			suite.requireSetCodeAuthorizationConsumed(authority, delegate, 1)
+		})
+	}
+}
+
+func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationSurvivesPostHookFailure() {
+	suite.SetupTest()
+	suite.App.EvmKeeper.SetHooks(keeper.NewMultiEvmHooks(FailureHook{}))
+
+	stateChangingTarget := common.HexToAddress("0x0000000000000000000000000000000000007703")
+	delegate := common.HexToAddress("0x000000000000000000000000000000000000dE1E")
+	authorityKey, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+	authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+
+	// PUSH1 0x02 PUSH1 0x01 SSTORE STOP
+	targetCode := common.FromHex("0x600260015500")
+	vmdb := suite.StateDB()
+	vmdb.SetCode(stateChangingTarget, targetCode, 0)
+	suite.Require().NoError(vmdb.Commit())
+
+	msg := suite.buildSetCodeTx(stateChangingTarget, authorityKey, delegate, 0, 100000)
+	res, err := suite.App.EvmKeeper.EthereumTx(suite.Ctx, msg)
+	suite.Require().NoError(err)
+	suite.Require().True(res.Failed())
+	suite.Require().Equal(types.ErrPostTxProcessing.Error(), res.VmError)
+	suite.Require().Empty(res.Logs)
+
+	suite.requireSetCodeAuthorizationConsumed(authority, delegate, 1)
+	storageValue := suite.StateDB().GetState(stateChangingTarget, common.BigToHash(big.NewInt(1)))
+	suite.Require().Equal(common.Hash{}, storageValue, "posthook failure must still roll back ordinary EVM state")
+}
+
+func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationDurableCtxIgnoredWhenCommitFalse() {
+	suite.SetupTest()
+
+	target := common.HexToAddress("0x0000000000000000000000000000000000007707")
+	delegate := common.HexToAddress("0x000000000000000000000000000000000000dE1E")
+	authorityKey, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+	authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+
+	cfg, err := suite.App.EvmKeeper.EVMConfig(suite.Ctx, suite.App.EvmKeeper.ChainID(), common.Hash{})
+	suite.Require().NoError(err)
+	cfg.DurableSetCodeAuthorizationCtx = &suite.Ctx
+
+	msgEth := suite.buildSetCodeTx(target, authorityKey, delegate, 0, 100000)
+	msg := msgEth.AsMessage(cfg.BaseFee)
+	res, err := suite.App.EvmKeeper.ApplyMessageWithConfig(suite.Ctx, msg, cfg, false)
+	suite.Require().NoError(err)
+	suite.Require().False(res.Failed())
+
+	vmdb := suite.StateDB()
+	suite.Require().Zero(vmdb.GetNonce(authority))
+	suite.Require().Empty(vmdb.GetCode(authority))
+}
+
+func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationReplayByDifferentOuterSignerSkippedAfterFailedExecution() {
+	testCases := []struct {
+		name       string
+		setupHooks func()
+	}{
+		{
+			name: "no hooks",
+		},
+		{
+			name: "hooks enabled",
+			setupHooks: func() {
+				suite.App.EvmKeeper.SetHooks(keeper.NewMultiEvmHooks(&LogRecordHook{}))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+			if tc.setupHooks != nil {
+				tc.setupHooks()
+			}
+
+			failingTarget := common.HexToAddress("0x0000000000000000000000000000000000007704")
+			successTarget := common.HexToAddress("0x0000000000000000000000000000000000007705")
+			delegate := common.HexToAddress("0x000000000000000000000000000000000000dE1E")
+			authorityKey, err := crypto.GenerateKey()
+			suite.Require().NoError(err)
+			replayKey, err := crypto.GenerateKey()
+			suite.Require().NoError(err)
+			authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+
+			vmdb := suite.StateDB()
+			vmdb.SetCode(failingTarget, common.FromHex("0x60006000fd"), 0)
+			suite.Require().NoError(vmdb.Commit())
+
+			auth := suite.signSetCodeAuthorization(authorityKey, delegate, 0)
+			firstMsg := suite.buildSetCodeTxWithAuth(failingTarget, suite.senderKey(), auth, 100000)
+			firstRes, err := suite.App.EvmKeeper.EthereumTx(suite.Ctx, firstMsg)
+			suite.Require().NoError(err)
+			suite.Require().True(firstRes.Failed())
+			suite.requireSetCodeAuthorizationConsumed(authority, delegate, 1)
+
+			replayMsg := suite.buildSetCodeTxWithAuth(successTarget, replayKey, auth, 100000)
+			replayRes, err := suite.App.EvmKeeper.EthereumTx(suite.Ctx, replayMsg)
+			suite.Require().NoError(err)
+			suite.Require().False(replayRes.Failed())
+
+			suite.requireSetCodeAuthorizationConsumed(authority, delegate, 1)
+		})
+	}
+}
+
+func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationReplayByDifferentOuterSignerSkippedAfterPostHookFailure() {
+	suite.SetupTest()
+	suite.App.EvmKeeper.SetHooks(keeper.NewMultiEvmHooks(&oneShotFailureHook{}))
+
+	successTarget := common.HexToAddress("0x0000000000000000000000000000000000007706")
+	delegate := common.HexToAddress("0x000000000000000000000000000000000000dE1E")
+	authorityKey, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+	replayKey, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+	authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+
+	auth := suite.signSetCodeAuthorization(authorityKey, delegate, 0)
+	firstMsg := suite.buildSetCodeTxWithAuth(successTarget, suite.senderKey(), auth, 100000)
+	firstRes, err := suite.App.EvmKeeper.EthereumTx(suite.Ctx, firstMsg)
+	suite.Require().NoError(err)
+	suite.Require().True(firstRes.Failed())
+	suite.Require().Equal(types.ErrPostTxProcessing.Error(), firstRes.VmError)
+	suite.requireSetCodeAuthorizationConsumed(authority, delegate, 1)
+
+	replayMsg := suite.buildSetCodeTxWithAuth(successTarget, replayKey, auth, 100000)
+	replayRes, err := suite.App.EvmKeeper.EthereumTx(suite.Ctx, replayMsg)
+	suite.Require().NoError(err)
+	suite.Require().False(replayRes.Failed())
+
+	suite.requireSetCodeAuthorizationConsumed(authority, delegate, 1)
+}
+
+func (suite *StateTransitionTestSuite) TestSetCodeAuthorizationDrainCallRolledBackButAuthorizationConsumedOnPostHookFailure() {
+	suite.SetupTest()
+	suite.App.EvmKeeper.SetHooks(keeper.NewMultiEvmHooks(FailureHook{}))
+
+	delegate := common.HexToAddress("0x000000000000000000000000000000000000dE1E")
+	victimBalance := uint256.NewInt(1000000000)
+	authorityKey, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+	outerKey, err := crypto.GenerateKey()
+	suite.Require().NoError(err)
+	authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+	outer := crypto.PubkeyToAddress(outerKey.PublicKey)
+
+	// CALL(CALLER, SELFBALANCE): a permissive delegate used by the PoC drain case.
+	drainRuntime := common.FromHex("0x600060006000600047335af100")
+	vmdb := suite.StateDB()
+	vmdb.SetCode(delegate, drainRuntime, 0)
+	vmdb.AddBalance(authority, victimBalance, 0)
+	suite.Require().NoError(vmdb.Commit())
+
+	auth := suite.signSetCodeAuthorization(authorityKey, delegate, 0)
+	msg := suite.buildSetCodeTxWithAuth(authority, outerKey, auth, 200000)
+	res, err := suite.App.EvmKeeper.EthereumTx(suite.Ctx, msg)
+	suite.Require().NoError(err)
+	suite.Require().True(res.Failed())
+	suite.Require().Equal(types.ErrPostTxProcessing.Error(), res.VmError)
+
+	suite.requireSetCodeAuthorizationConsumed(authority, delegate, 1)
+	suite.Require().Equal(victimBalance.ToBig(), suite.App.EvmKeeper.GetEVMDenomBalance(suite.Ctx, authority))
+	suite.Require().Zero(suite.App.EvmKeeper.GetEVMDenomBalance(suite.Ctx, outer).Sign())
+}
+
+func (suite *StateTransitionTestSuite) buildSetCodeTx(
+	to common.Address,
+	authorityKey *ecdsa.PrivateKey,
+	delegate common.Address,
+	authorityNonce uint64,
+	gasLimit uint64,
+) *types.MsgEthereumTx {
+	auth := suite.signSetCodeAuthorization(authorityKey, delegate, authorityNonce)
+	return suite.buildSetCodeTxWithAuth(to, suite.senderKey(), auth, gasLimit)
+}
+
+func (suite *StateTransitionTestSuite) signSetCodeAuthorization(
+	authorityKey *ecdsa.PrivateKey,
+	delegate common.Address,
+	authorityNonce uint64,
+) ethtypes.SetCodeAuthorization {
+	auth, err := ethtypes.SignSetCode(authorityKey, ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(suite.App.EvmKeeper.ChainID()),
+		Address: delegate,
+		Nonce:   authorityNonce,
+	})
+	suite.Require().NoError(err)
+	return auth
+}
+
+func (suite *StateTransitionTestSuite) buildSetCodeTxWithAuth(
+	to common.Address,
+	outerKey *ecdsa.PrivateKey,
+	auth ethtypes.SetCodeAuthorization,
+	gasLimit uint64,
+) *types.MsgEthereumTx {
+	outer := crypto.PubkeyToAddress(outerKey.PublicKey)
+	tx := ethtypes.NewTx(&ethtypes.SetCodeTx{
+		ChainID:   uint256.MustFromBig(suite.App.EvmKeeper.ChainID()),
+		Nonce:     suite.App.EvmKeeper.GetNonce(suite.Ctx, outer),
+		GasTipCap: uint256.NewInt(0),
+		GasFeeCap: uint256.NewInt(0),
+		Gas:       gasLimit,
+		To:        to,
+		Value:     uint256.NewInt(0),
+		AuthList:  []ethtypes.SetCodeAuthorization{auth},
+	})
+
+	signer := ethtypes.NewPragueSigner(suite.App.EvmKeeper.ChainID())
+	signedTx, err := ethtypes.SignTx(tx, signer, outerKey)
+	suite.Require().NoError(err)
+
+	msg := &types.MsgEthereumTx{}
+	suite.Require().NoError(msg.FromSignedEthereumTx(signedTx, signer))
+	return msg
+}
+
+func (suite *StateTransitionTestSuite) senderKey() *ecdsa.PrivateKey {
+	senderKey, err := crypto.ToECDSA(suite.PrivKey.Key)
+	suite.Require().NoError(err)
+	return senderKey
+}
+
+func (suite *StateTransitionTestSuite) requireSetCodeAuthorizationConsumed(
+	authority common.Address,
+	delegate common.Address,
+	expectedNonce uint64,
+) {
+	vmdb := suite.StateDB()
+	suite.Require().Equal(expectedNonce, vmdb.GetNonce(authority))
+	suite.Require().Equal(ethtypes.AddressToDelegation(delegate), vmdb.GetCode(authority))
+}
+
+type oneShotFailureHook struct {
+	called bool
+}
+
+func (h *oneShotFailureHook) PostTxProcessing(ctx sdk.Context, msg *core.Message, receipt *ethtypes.Receipt) error {
+	if h.called {
+		return nil
+	}
+	h.called = true
+	return fmt.Errorf("mock transient error")
 }
 
 func (suite *StateTransitionTestSuite) createContractGethMsg(nonce uint64, signer ethtypes.Signer, gasPrice *big.Int) (*core.Message, error) {


### PR DESCRIPTION
When EVM post-tx hooks are enabled, EIP-7702 authorization effects lived inside the hook tmpCtx and were rolled back together with the rest of the transaction state if either:
 - the EVM call itself failed, or
 - a post-tx hook returned an error
 
This PR makes the authorization lifecycle durable independently of the hook cache