### PR TITLE
feat(rpc): implement txpool namespace (content/inspect/status/contentFrom) backed by app mempool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (rpc) [#1031](https://github.com/crypto-org-chain/ethermint/pull/1031) feat(rpc): include txHash in `debug_traceBlock` JSON RPC.
 * (rpc) [#1003](https://github.com/crypto-org-chain/ethermint/pull/1003) feat(rpc): direct app-mempool insert for EVM tx submission.
 * (rpc) [#1016](https://github.com/crypto-org-chain/ethermint/pull/1016) refactor(rpc): support mempool insertion from api.
+* (rpc) [#1019](https://github.com/crypto-org-chain/ethermint/pull/1019) feat(rpc): implement txpool namespace (content/inspect/status/contentFrom) backed by app mempool.
 * (deps) [#894](https://github.com/crypto-org-chain/ethermint/pull/894) feat: migrate to Cosmos SDK v0.54.3, IBC v11, CometBFT v0.39.3.
 * (ante) [#948](https://github.com/crypto-org-chain/ethermint/pull/948) fix(ante): enforce eip-1559 cost balance check even if it is not checkTx.
 * (evm) [#948](https://github.com/crypto-org-chain/ethermint/pull/948) fix(evm): fix SetCodeTx nil pointer panics, missing AuthList in Copy.

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -177,8 +177,8 @@ schema = 3
     version = "v2.3.5"
     hash = "sha256-stpoaGQ1PNPqtLYIQc96YH24s8owcV+PoSo6xREi9LI="
   [mod."github.com/btcsuite/btcd/btcutil"]
-    version = "v1.1.6"
-    hash = "sha256-TYbwJLNX/+63nm+b3RqPH3ZIvTBnsm9peqJP05v9Z90="
+    version = "v1.2.0"
+    hash = "sha256-XT3GG5PoTBNhnRDnmj1kf6YsYoVW6MJB/XJq0aKxtys="
   [mod."github.com/btcsuite/btcd/chaincfg/chainhash"]
     version = "v1.1.0"
     hash = "sha256-F+EqvufC+KBslZV/vL8ph6MqDoVD5ic5rVaM27reDqo="
@@ -268,8 +268,8 @@ schema = 3
     version = "v1.2.8"
     hash = "sha256-9eqXqTs5UjfYmxFiTVR6sm8/56gGSq3WKoN3xss/OFk="
   [mod."github.com/cosmos/ibc-go/v11"]
-    version = "v11.0.0"
-    hash = "sha256-quFHU6vHmDigd2BxwH/khZebwjqYADvdx0vE073IEqk="
+    version = "v11.1.0"
+    hash = "sha256-wNqlnX3OXFspJlRTmIKd+SjbpU+lCzI5pmv+6sEBiJc="
   [mod."github.com/cosmos/ics23/go"]
     version = "v0.11.0"
     hash = "sha256-mgU/pqp4kASmW/bP0z6PzssfjRp7GU9ioyvNlDdGC+E="
@@ -431,8 +431,8 @@ schema = 3
     version = "v0.0.1"
     hash = "sha256-KrExYovtUQrHGI1mPQf57jGw8soz7eWOC2xqEaV0uGk="
   [mod."github.com/google/pprof"]
-    version = "v0.0.0-20260115054156-294ebfa9ad83"
-    hash = "sha256-fhalKl/thSt1gdsHZmFyNGF1Gwxb0YLXV0pBv65EZjE="
+    version = "v0.0.0-20260402051712-545e8a4df936"
+    hash = "sha256-DBaCmfVLei1HComa+xJN76IpPFTUaDfUEhc1U9gmW8g="
   [mod."github.com/google/s2a-go"]
     version = "v0.1.9"
     hash = "sha256-0AdSpSTso4bATmM/9qamWzKrVtOLDf7afvDhoiT/UpA="
@@ -538,6 +538,9 @@ schema = 3
   [mod."github.com/jmhodges/levigo"]
     version = "v1.0.0"
     hash = "sha256-xEd0mDBeq3eR/GYeXjoTVb2sPs8sTCosn5ayWkcgENI="
+  [mod."github.com/kcalvinalvin/anet"]
+    version = "v0.0.0-20251112173137-d8ddc1f6dbee"
+    hash = "sha256-GBQuTXh6oQI4caoM6gJgWXolh7c/fTCNiYnFNfGeRaU="
   [mod."github.com/klauspost/compress"]
     version = "v1.18.5"
     hash = "sha256-H9b5iFJf4XbEnkGQCjGQAJ3aYhVDiolKrDewTbhuzQo="
@@ -677,11 +680,11 @@ schema = 3
     version = "v0.0.5"
     hash = "sha256-/5i70IkH/qSW5KjGzv8aQNKh9tHoz98tqtL0K2DMFn4="
   [mod."github.com/onsi/ginkgo/v2"]
-    version = "v2.28.0"
-    hash = "sha256-p5cif8IrShko0DyGHkdjnDaHc+S8ZiQ9dKsOz8nogzQ="
+    version = "v2.32.0"
+    hash = "sha256-EHQbD61XSnuHx36LFDwp0OPnmefB7KyifgkfqoIJcEs="
   [mod."github.com/onsi/gomega"]
-    version = "v1.39.1"
-    hash = "sha256-ZlbQhUVwQBzmhBWCQ9iPWoJOVr+OqqIHB4iCNDFMEds="
+    version = "v1.42.1"
+    hash = "sha256-VtQLikXkQ4mhZaT8SfEcVsaDodZIewo9WVNPJhiZf14="
   [mod."github.com/pbnjay/memory"]
     version = "v0.0.0-20210728143218-7b4eea64cf58"
     hash = "sha256-QI+F1oPLOOtwNp8+m45OOoSfYFs3QVjGzE0rFdpF/IA="
@@ -800,8 +803,8 @@ schema = 3
     version = "v1.11.1"
     hash = "sha256-0z4aFR5VjuVYn+XnANbjui0ADcdG7gU56A9Y/NtrzCQ="
   [mod."github.com/rs/zerolog"]
-    version = "v1.35.0"
-    hash = "sha256-HMu0f8l3MQPH7gsm7rNZ7iJoWOgWcw+vEcnTgmEkwQA="
+    version = "v1.35.1"
+    hash = "sha256-JMry/37tnOV0ZUCeWRsduxb3WehvbLxUUZfF2l+Cz/s="
   [mod."github.com/sagikazarmark/locafero"]
     version = "v0.11.0"
     hash = "sha256-PUX8dzJtkD8YDZFNqpHnl4qgb0tE1W/DLnL7V+/d1z4="
@@ -864,8 +867,8 @@ schema = 3
     version = "v1.8.1"
     hash = "sha256-QsYonFnbD/zaxUYAJMzDNI3ju0TjcBJrh8/DBhaJfbM="
   [mod."github.com/tidwall/gjson"]
-    version = "v1.18.0"
-    hash = "sha256-CO6hqDu8Y58Po6A01e5iTpwiUBQ5khUZsw7czaJHw0I="
+    version = "v1.19.0"
+    hash = "sha256-H0tqaftwuKVjuvlPov1Fr1a5W0JZmWUkOlPxY5qtSTE="
   [mod."github.com/tidwall/match"]
     version = "v1.1.1"
     hash = "sha256-M2klhPId3Q3T3VGkSbOkYl/2nLHnsG+yMbXkPkyrRdg="
@@ -1026,41 +1029,41 @@ schema = 3
     version = "v0.26.0"
     hash = "sha256-xssXQRlEa2O2Dv4lfLsshYIn2r67nhBPOdvL58MnEXo="
   [mod."golang.org/x/crypto"]
-    version = "v0.51.0"
-    hash = "sha256-/R74sc1mcOaOuBeXRQzrXrHAgA5VhNWc6SfQJaxb17U="
+    version = "v0.53.0"
+    hash = "sha256-TWcccM4d5t0ZbDyHXEm4elxKk5uzlo29i85lVHSZcNw="
   [mod."golang.org/x/exp"]
     version = "v0.0.0-20260312153236-7ab1446f8b90"
     hash = "sha256-q4a4MK4pVmaazKo9DTOwocH6Fvo8NsO96YeY9FJmNyo="
   [mod."golang.org/x/mod"]
-    version = "v0.35.0"
-    hash = "sha256-ICEQxokHywOFInDPqoP+go9l1tZSz3roknF5SXPtNV4="
+    version = "v0.36.0"
+    hash = "sha256-ZhyOvy9ptbV+pna/CNyQFr5cKRn5O+B2QzkQAISKgco="
   [mod."golang.org/x/net"]
-    version = "v0.55.0"
-    hash = "sha256-Phi2mSmBGOJcvqPPAit3uqF3UP8SKRI9dHj6yTM3s5s="
+    version = "v0.56.0"
+    hash = "sha256-JUORjxDZqZanYWo2yunaDpQ2/zvHiFb0TnF1Jw6D+30="
   [mod."golang.org/x/oauth2"]
     version = "v0.36.0"
     hash = "sha256-evS7WkMrpgonmTcqtWFpC5rSKZN8O+vnAhNUs1MS9kw="
   [mod."golang.org/x/sync"]
-    version = "v0.20.0"
-    hash = "sha256-ybcjhCfK6lroUM0yswUvWooW8MOQZBXyiSqoxG6Uy0Y="
+    version = "v0.21.0"
+    hash = "sha256-2n7PVb1krz7UpnXYGVmCrxV0fZBnjQdVVt6eVudEPYY="
   [mod."golang.org/x/sys"]
-    version = "v0.45.0"
-    hash = "sha256-hkBoNazrDA67ER6sWhb+EKxx9nJ24+nz3zGy+zT5Hvw="
+    version = "v0.46.0"
+    hash = "sha256-NzRXMSEk6upeudJvUEPVnw6clJ3d8UdC/vdfANWAc8g="
   [mod."golang.org/x/telemetry"]
-    version = "v0.0.0-20260409153401-be6f6cb8b1fa"
-    hash = "sha256-NH3t7QaWURhZnwukd4+/w2VdFYpaF0dFTyKlKXuuKew="
+    version = "v0.0.0-20260508192327-42602be52be6"
+    hash = "sha256-jK+VMNDRQd4CLjTMX59k+6QMwWxdRQF9ErEgsQN5D+s="
   [mod."golang.org/x/term"]
-    version = "v0.43.0"
-    hash = "sha256-gFV1oGgs/vpRamvDWmu93voN57iyZMk/hh+oL8L9VrQ="
+    version = "v0.44.0"
+    hash = "sha256-nzbvOgvGRbx1qpq1rbk7b6zNsNeNj8mOGoyZLtnzq3w="
   [mod."golang.org/x/text"]
-    version = "v0.37.0"
-    hash = "sha256-8XDOnlPIybcDRy89fkjG5VqtIt5Ku+LmaqYhgKl7i1E="
+    version = "v0.38.0"
+    hash = "sha256-PzREcn7yzTAJ0WBvyYL/2/r+tfoeKTY/E5HVXi/CJsU="
   [mod."golang.org/x/time"]
     version = "v0.15.0"
     hash = "sha256-5D24A65wn7k93Jj3+918UKjB9ccmGHPBEqjD2XDB92E="
   [mod."golang.org/x/tools"]
-    version = "v0.44.0"
-    hash = "sha256-xuj5FLtSJsAojLLTLXtPdLAIFNTKoVFbDMuqRXmj2W4="
+    version = "v0.45.0"
+    hash = "sha256-fKsYC186cbOCJROZGUqU6UMSxvK2DZ44hlCEytLvp5c="
   [mod."google.golang.org/api"]
     version = "v0.276.0"
     hash = "sha256-qXHX3iYmJD3Pb1vaCaTwSoqvTdbnNljndShDM8sSJUM="
@@ -1074,8 +1077,8 @@ schema = 3
     version = "v0.0.0-20260414002931-afd174a4e478"
     hash = "sha256-ldJTTb7hhj1mdmzTn9IEkQVwCoj3KRlENZtUSEKHABU="
   [mod."google.golang.org/grpc"]
-    version = "v1.80.0"
-    hash = "sha256-+p50KGJvGWdpB/4f0h477dCAfoOL5m2PzG8BGOekVgY="
+    version = "v1.81.1"
+    hash = "sha256-YZ5KMHmN1HvsMxyIBIl3SmFmL3r+6bwjzzFLxUFhm1o="
   [mod."google.golang.org/protobuf"]
     version = "v1.36.11"
     hash = "sha256-7W+6jntfI/awWL3JP6yQedxqP5S9o3XvPgJ2XxxsIeE="

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -482,8 +482,8 @@ schema = 3
     version = "v1.3.1"
     hash = "sha256-65+A2HiVfS/GV9G+6/TkXXjzXhI/V98e6RlJWjxy+mg="
   [mod."github.com/hashicorp/go-metrics"]
-    version = "v0.5.4"
-    hash = "sha256-WQGb38CuijG9YxHfqgKn1U655BmxLYhNXXdSw0MRiGc="
+    version = "v0.6.0"
+    hash = "sha256-EJ6FZlQpPBQrPT0E2SNrKsqLu7APJPO/XVt9M/+FZp8="
   [mod."github.com/hashicorp/go-plugin"]
     version = "v1.7.0"
     hash = "sha256-nPTlKEssbp3/uDRZ2kkdO8z5mbu3j417Bra4FpBceHk="

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -142,14 +142,18 @@ func init() {
 				},
 			}
 		},
-		TxPoolNamespace: func(ctx *server.Context, _ client.Context, _ *stream.RPCStream,
-			_ bool, _ ethermint.EVMTxIndexer, _ appmempool.MempoolClient,
+		TxPoolNamespace: func(ctx *server.Context,
+			clientCtx client.Context,
+			_ *stream.RPCStream,
+			_ bool,
+			_ ethermint.EVMTxIndexer,
+			mempoolClient appmempool.MempoolClient,
 		) []rpc.API {
 			return []rpc.API{
 				{
 					Namespace: TxPoolNamespace,
 					Version:   apiVersion,
-					Service:   txpool.NewPublicAPI(ctx.Logger),
+					Service:   txpool.NewPublicAPI(ctx.Logger, clientCtx, mempoolClient),
 					Public:    true,
 				},
 			}

--- a/rpc/namespaces/ethereum/txpool/api.go
+++ b/rpc/namespaces/ethereum/txpool/api.go
@@ -16,51 +16,152 @@
 package txpool
 
 import (
+	"fmt"
+	"math/big"
+	"strconv"
+
 	"cosmossdk.io/log/v2"
 
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
+	"github.com/evmos/ethermint/appmempool"
 	"github.com/evmos/ethermint/rpc/types"
+	ethermint "github.com/evmos/ethermint/types"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
 )
 
-// PublicAPI offers and API for the transaction pool. It only operates on data that is non-confidential.
-// NOTE: For more info about the current status of this endpoints see https://github.com/evmos/ethermint/issues/124
+const (
+	pendingKey = "pending"
+	queuedKey  = "queued"
+)
+
+// PublicAPI offers the transaction pool API for non-confidential data.
 type PublicAPI struct {
-	logger log.Logger
+	logger  log.Logger
+	chainID *big.Int
+	client  appmempool.MempoolClient
 }
 
-// NewPublicAPI creates a new tx pool service that gives information about the transaction pool.
-func NewPublicAPI(logger log.Logger) *PublicAPI {
+// NewPublicAPI creates the txpool service. A nil client reports empty pools.
+func NewPublicAPI(logger log.Logger, clientCtx client.Context, client appmempool.MempoolClient) *PublicAPI {
+	chainID, err := ethermint.ParseChainID(clientCtx.ChainID)
+	if err != nil {
+		panic(err)
+	}
 	return &PublicAPI{
-		logger: logger.With("module", "txpool"),
+		logger:  logger.With("module", "txpool"),
+		chainID: chainID,
+		client:  client,
 	}
 }
 
-// Content returns the transactions contained within the transaction pool
+// pending returns EVM txs that pass keep, keyed by sender → nonce.
+// Note: pending/queued split is not supported; all txs are treated as pending.
+// Nil keep includes all senders. Block fields are zero (txs not yet mined).
+func (api *PublicAPI) pending(keep func(common.Address) bool) map[common.Address]map[uint64]*types.RPCTransaction {
+	byAddr := make(map[common.Address]map[uint64]*types.RPCTransaction)
+	if api.client == nil {
+		return byAddr
+	}
+	for _, sdkTx := range api.client.PendingTxs() {
+		for _, msg := range sdkTx.GetMsgs() {
+			ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
+			if !ok {
+				continue
+			}
+			rpcTx, err := types.NewRPCTransaction(ethMsg, common.Hash{}, 0, 0, 0, nil, api.chainID)
+			if err != nil {
+				api.logger.Debug("failed to convert pending tx", "error", err.Error())
+				continue
+			}
+			// Filter using the sender from the converted RPC tx to ensure consistency.
+			if keep != nil && !keep(rpcTx.From) {
+				continue
+			}
+			if byAddr[rpcTx.From] == nil {
+				byAddr[rpcTx.From] = make(map[uint64]*types.RPCTransaction)
+			}
+			byAddr[rpcTx.From][uint64(rpcTx.Nonce)] = rpcTx
+		}
+	}
+	return byAddr
+}
+
+// Content returns pool transactions. All txs are reported as pending;
+// pending/queued split is not supported.
 func (api *PublicAPI) Content() (map[string]map[string]map[string]*types.RPCTransaction, error) {
 	api.logger.Debug("txpool_content")
-	content := map[string]map[string]map[string]*types.RPCTransaction{
-		"pending": make(map[string]map[string]*types.RPCTransaction),
-		"queued":  make(map[string]map[string]*types.RPCTransaction),
+	pending := make(map[string]map[string]*types.RPCTransaction)
+	for addr, txs := range api.pending(nil) {
+		dump := make(map[string]*types.RPCTransaction, len(txs))
+		for nonce, tx := range txs {
+			dump[strconv.FormatUint(nonce, 10)] = tx
+		}
+		pending[addr.Hex()] = dump
 	}
-	return content, nil
+	return map[string]map[string]map[string]*types.RPCTransaction{
+		pendingKey: pending,
+		queuedKey:  make(map[string]map[string]*types.RPCTransaction),
+	}, nil
 }
 
-// Inspect returns the content of the transaction pool and flattens it into an
+// ContentFrom returns pending and queued transactions for the given address.
+func (api *PublicAPI) ContentFrom(address common.Address) (map[string]map[string]*types.RPCTransaction, error) {
+	api.logger.Debug("txpool_contentFrom", "address", address.Hex())
+	pending := make(map[string]*types.RPCTransaction)
+	fromSender := api.pending(func(a common.Address) bool { return a == address })
+	for nonce, tx := range fromSender[address] {
+		pending[strconv.FormatUint(nonce, 10)] = tx
+	}
+	return map[string]map[string]*types.RPCTransaction{
+		pendingKey: pending,
+		queuedKey:  make(map[string]*types.RPCTransaction),
+	}, nil
+}
+
+// Inspect returns a textual summary of pending and queued transactions.
 func (api *PublicAPI) Inspect() (map[string]map[string]map[string]string, error) {
 	api.logger.Debug("txpool_inspect")
-	content := map[string]map[string]map[string]string{
-		"pending": make(map[string]map[string]string),
-		"queued":  make(map[string]map[string]string),
+	pending := make(map[string]map[string]string)
+	for addr, txs := range api.pending(nil) {
+		dump := make(map[string]string, len(txs))
+		for nonce, tx := range txs {
+			dump[strconv.FormatUint(nonce, 10)] = InspectFormat(tx)
+		}
+		pending[addr.Hex()] = dump
 	}
-	return content, nil
+	return map[string]map[string]map[string]string{
+		pendingKey: pending,
+		queuedKey:  make(map[string]map[string]string),
+	}, nil
 }
 
-// Status returns the number of pending and queued transaction in the pool.
+// Status returns pending and queued transaction counts.
 func (api *PublicAPI) Status() map[string]hexutil.Uint {
 	api.logger.Debug("txpool_status")
-	return map[string]hexutil.Uint{
-		"pending": hexutil.Uint(0),
-		"queued":  hexutil.Uint(0),
+	var count int
+	for _, txs := range api.pending(nil) {
+		count += len(txs)
 	}
+	return map[string]hexutil.Uint{
+		pendingKey: hexutil.Uint(count), //#nosec G115 -- count is a non-negative count
+		queuedKey:  hexutil.Uint(0),
+	}
+}
+
+// InspectFormat renders a tx as "to: value wei + gas gas × gasPrice wei"
+// (txpool_inspect format).
+func InspectFormat(tx *types.RPCTransaction) string {
+	to := "contract creation"
+	if tx.To != nil {
+		to = tx.To.Hex()
+	}
+	gasPrice := tx.GasPrice
+	if gasPrice == nil {
+		gasPrice = tx.GasFeeCap // EIP-1559 pending txs have no mined GasPrice.
+	}
+	return fmt.Sprintf("%s: %v wei + %v gas × %v wei",
+		to, (*big.Int)(tx.Value), uint64(tx.Gas), (*big.Int)(gasPrice))
 }

--- a/rpc/namespaces/ethereum/txpool/api_test.go
+++ b/rpc/namespaces/ethereum/txpool/api_test.go
@@ -1,0 +1,227 @@
+package txpool
+
+import (
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/log/v2"
+	protov2 "google.golang.org/protobuf/proto"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/evmos/ethermint/appmempool"
+	"github.com/evmos/ethermint/crypto/ethsecp256k1"
+	rpctypes "github.com/evmos/ethermint/rpc/types"
+	"github.com/evmos/ethermint/tests"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+)
+
+var (
+	testChainID = big.NewInt(9000)
+	testTo      = common.HexToAddress("0x1234567890123456789012345678901234567890")
+)
+
+// clientFunc adapts a plain pending-txs function to appmempool.MempoolClient
+// for tests; InsertTx is unused here.
+type clientFunc func() []*evmtypes.MsgEthereumTx
+
+// singleMsgTx wraps a sdk.Msg as a minimal sdk.Tx for test purposes.
+type singleMsgTx struct{ msg sdk.Msg }
+
+func (t singleMsgTx) GetMsgs() []sdk.Msg                          { return []sdk.Msg{t.msg} }
+func (singleMsgTx) GetMsgsV2() ([]protov2.Message, error)         { return nil, nil }
+func (singleMsgTx) ValidateBasic() error                           { return nil }
+
+func (f clientFunc) PendingTxs() []sdk.Tx {
+	ethMsgs := f()
+	out := make([]sdk.Tx, len(ethMsgs))
+	for i, m := range ethMsgs {
+		out[i] = singleMsgTx{m}
+	}
+	return out
+}
+func (clientFunc) InsertTx([]byte) (*sdk.TxResponse, error) { return nil, nil }
+
+// newAPI builds a PublicAPI over a pending-txs func; a nil func maps to a nil
+// interface so the empty-pool path is exercised faithfully.
+func newAPI(reader func() []*evmtypes.MsgEthereumTx) *PublicAPI {
+	clientCtx := client.Context{}.WithChainID("ethermint_9000-1")
+	var c appmempool.MempoolClient
+	if reader != nil {
+		c = clientFunc(reader)
+	}
+	return NewPublicAPI(log.NewNopLogger(), clientCtx, c)
+}
+
+// newSender returns a fresh signer and its address.
+func newSender(t *testing.T) (keyring.Signer, common.Address) {
+	t.Helper()
+	privKey, err := ethsecp256k1.GenerateKey()
+	require.NoError(t, err)
+	return tests.NewSigner(privKey), common.BytesToAddress(privKey.PubKey().Address().Bytes())
+}
+
+func signedTx(t *testing.T, signer keyring.Signer, from common.Address, nonce uint64) *evmtypes.MsgEthereumTx {
+	t.Helper()
+	tx := evmtypes.NewTx(testChainID, nonce, &testTo, big.NewInt(1000), 21000, big.NewInt(1000000000), nil, nil, nil, nil)
+	tx.From = from.Bytes()
+	require.NoError(t, tx.Sign(ethtypes.LatestSignerForChainID(testChainID), signer))
+	return tx
+}
+
+func signedEIP1559Tx(t *testing.T, signer keyring.Signer, from common.Address, nonce uint64) *evmtypes.MsgEthereumTx {
+	t.Helper()
+	gasTipCap := big.NewInt(1_000_000_000)
+	gasFeeCap := big.NewInt(2_000_000_000)
+	tx := evmtypes.NewTx(testChainID, nonce, &testTo, big.NewInt(1000), 21000, nil, gasFeeCap, gasTipCap, nil, nil)
+	tx.From = from.Bytes()
+	require.NoError(t, tx.Sign(ethtypes.LatestSignerForChainID(testChainID), signer))
+	return tx
+}
+
+func TestContentFrom(t *testing.T) {
+	signerA, addrA := newSender(t)
+	signerB, addrB := newSender(t)
+	reader := func() []*evmtypes.MsgEthereumTx {
+		return []*evmtypes.MsgEthereumTx{
+			signedTx(t, signerA, addrA, 0),
+			signedTx(t, signerA, addrA, 1),
+			signedTx(t, signerB, addrB, 0),
+		}
+	}
+	api := newAPI(reader)
+
+	res, err := api.ContentFrom(addrA)
+	require.NoError(t, err)
+	require.Len(t, res["pending"], 2)
+	require.Empty(t, res["queued"])
+	require.Equal(t, addrA, res["pending"]["0"].From)
+	require.Equal(t, hexutil.Uint64(1), res["pending"]["1"].Nonce)
+
+	res, err = api.ContentFrom(addrB)
+	require.NoError(t, err)
+	require.Len(t, res["pending"], 1)
+	require.Equal(t, addrB, res["pending"]["0"].From)
+
+	// Unknown sender yields empty (non-nil) pools.
+	res, err = api.ContentFrom(common.HexToAddress("0xdead"))
+	require.NoError(t, err)
+	require.Empty(t, res["pending"])
+	require.NotNil(t, res["pending"])
+}
+
+func TestContent(t *testing.T) {
+	signerA, addrA := newSender(t)
+	signerB, addrB := newSender(t)
+	api := newAPI(func() []*evmtypes.MsgEthereumTx {
+		return []*evmtypes.MsgEthereumTx{
+			signedTx(t, signerA, addrA, 0),
+			signedTx(t, signerA, addrA, 1),
+			signedTx(t, signerB, addrB, 7),
+		}
+	})
+
+	content, err := api.Content()
+	require.NoError(t, err)
+	require.Len(t, content["pending"], 2) // two senders
+	require.Empty(t, content["queued"])
+	require.Len(t, content["pending"][addrA.Hex()], 2)
+	require.Contains(t, content["pending"][addrB.Hex()], "7")
+}
+
+func TestStatus(t *testing.T) {
+	signer, addr := newSender(t)
+	api := newAPI(func() []*evmtypes.MsgEthereumTx {
+		return []*evmtypes.MsgEthereumTx{
+			signedTx(t, signer, addr, 0),
+			signedTx(t, signer, addr, 1),
+		}
+	})
+
+	status := api.Status()
+	require.Equal(t, hexutil.Uint(2), status["pending"])
+	require.Equal(t, hexutil.Uint(0), status["queued"])
+}
+
+// Status counts unique (sender, nonce) slots, matching Content which keys by
+// nonce. Two txs sharing a nonce (a replacement) count once.
+func TestStatusDedupesNonce(t *testing.T) {
+	signer, addr := newSender(t)
+	api := newAPI(func() []*evmtypes.MsgEthereumTx {
+		return []*evmtypes.MsgEthereumTx{
+			signedTx(t, signer, addr, 0),
+			signedTx(t, signer, addr, 0), // same nonce, replacement
+		}
+	})
+
+	require.Equal(t, hexutil.Uint(1), api.Status()["pending"])
+
+	content, err := api.Content()
+	require.NoError(t, err)
+	require.Len(t, content["pending"][addr.Hex()], 1) // Status matches Content
+}
+
+func TestInspect(t *testing.T) {
+	signer, addr := newSender(t)
+	api := newAPI(func() []*evmtypes.MsgEthereumTx {
+		return []*evmtypes.MsgEthereumTx{signedTx(t, signer, addr, 0)}
+	})
+
+	inspect, err := api.Inspect()
+	require.NoError(t, err)
+	require.Empty(t, inspect["queued"])
+	require.Contains(t, inspect["pending"][addr.Hex()]["0"], testTo.Hex())
+}
+
+// A nil reader (app without mempool access) reports empty pools, not errors.
+func TestNilReader(t *testing.T) {
+	api := newAPI(nil)
+
+	content, err := api.Content()
+	require.NoError(t, err)
+	require.Empty(t, content["pending"])
+
+	from, err := api.ContentFrom(testTo)
+	require.NoError(t, err)
+	require.Empty(t, from["pending"])
+
+	require.Equal(t, hexutil.Uint(0), api.Status()["pending"])
+}
+
+// TestInspectEIP1559 confirms Inspect formats EIP-1559 txs correctly.
+// For unmined txs (no base fee), GasPrice is set to GasFeeCap by NewRPCTransaction.
+func TestInspectEIP1559(t *testing.T) {
+	signer, addr := newSender(t)
+	api := newAPI(func() []*evmtypes.MsgEthereumTx {
+		return []*evmtypes.MsgEthereumTx{signedEIP1559Tx(t, signer, addr, 0)}
+	})
+
+	inspect, err := api.Inspect()
+	require.NoError(t, err)
+	s := inspect["pending"][addr.Hex()]["0"]
+	require.Contains(t, s, testTo.Hex())
+	require.Contains(t, s, "2000000000 wei")
+}
+
+// TestSummaryNilGasPrice confirms summary falls back to GasFeeCap when GasPrice
+// is nil, preventing "<nil>" in txpool_inspect output.
+func TestSummaryNilGasPrice(t *testing.T) {
+	gasFeeCap := big.NewInt(2_000_000_000)
+	tx := &rpctypes.RPCTransaction{
+		To:        &testTo,
+		Value:     (*hexutil.Big)(big.NewInt(1000)),
+		Gas:       21000,
+		GasFeeCap: (*hexutil.Big)(gasFeeCap),
+		GasPrice:  nil,
+	}
+	s := InspectFormat(tx)
+	require.Contains(t, s, testTo.Hex())
+	require.Contains(t, s, gasFeeCap.String()+" wei")
+	require.NotContains(t, s, "<nil>")
+}

--- a/tests/integration_tests/configs/txpool.jsonnet
+++ b/tests/integration_tests/configs/txpool.jsonnet
@@ -1,0 +1,16 @@
+local default = import 'default.jsonnet';
+
+default {
+  'ethermint_9000-1'+: {
+    config+: {
+      consensus+: {
+        timeout_commit: '5s',
+      },
+    },
+    'app-config'+: {
+      'json-rpc'+: {
+        api: 'eth,net,web3,debug,txpool',
+      },
+    },
+  },
+}

--- a/tests/integration_tests/test_txpool.py
+++ b/tests/integration_tests/test_txpool.py
@@ -1,0 +1,231 @@
+"""Integration tests for txpool_content, txpool_contentFrom, txpool_status and
+txpool_inspect."""
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import web3
+from web3 import Web3
+from web3.middleware import ExtraDataToPOAMiddleware
+
+from .network import Geth, setup_custom_ethermint
+from .utils import ADDRS, KEYS, sign_transaction, w3_wait_for_new_blocks, wait_for_port
+
+
+@pytest.fixture(scope="module")
+def custom_ethermint(tmp_path_factory):
+    path = tmp_path_factory.mktemp("txpool")
+    cfg = Path(__file__).parent / "configs/txpool.jsonnet"
+    yield from setup_custom_ethermint(path, 26850, cfg)
+
+
+@pytest.fixture(scope="module")
+def txpool_geth(tmp_path_factory):
+    path = tmp_path_factory.mktemp("txpool_geth")
+    port = 8646
+    with (path / "geth.log").open("w") as logfile:
+        cmd = [
+            "start-geth",
+            str(path),
+            "--http.port",
+            str(port),
+            "--port",
+            str(port + 1),
+            "--miner.etherbase",
+            "0x57f96e6B86CdeFdB3d412547816a82E3E0EbF9D2",
+            "--http.api",
+            "eth,net,web3,debug,txpool",
+        ]
+        proc = subprocess.Popen(
+            cmd,
+            preexec_fn=os.setsid,
+            stdout=logfile,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            wait_for_port(port)
+            w3 = web3.Web3(web3.providers.HTTPProvider(f"http://127.0.0.1:{port}"))
+            w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
+            yield Geth(w3)
+        finally:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            proc.wait()
+
+
+def assert_pending_rpc_tx_schema(tx, label=""):
+    """Assert the required pending RPCTransaction fields are Geth-compatible."""
+    null_in_pending = ("blockHash", "blockNumber", "transactionIndex")
+    hex_fields = (
+        "gas",
+        "gasPrice",
+        "hash",
+        "input",
+        "nonce",
+        "value",
+        "type",
+        "v",
+        "r",
+        "s",
+    )
+    str_fields = ("from",)
+
+    prefix = f"{label}: " if label else ""
+    required = set(null_in_pending) | set(hex_fields) | set(str_fields)
+    missing = required - set(tx)
+    assert not missing, f"{prefix}missing keys in pending RPCTransaction: {missing}"
+
+    for key in null_in_pending:
+        assert tx[key] is None, (
+            f"{prefix}'{key}' must be null for a pending tx, got {tx[key]!r}"
+        )
+
+    for key in hex_fields:
+        assert isinstance(tx[key], str), (
+            f"{prefix}'{key}' must be a string, got {type(tx[key]).__name__}"
+        )
+        assert tx[key].startswith("0x"), (
+            f"{prefix}'{key}' must be 0x-prefixed, got {tx[key]!r}"
+        )
+
+    for key in str_fields:
+        assert isinstance(tx[key], str), (
+            f"{prefix}'{key}' must be a string, got {type(tx[key]).__name__}"
+        )
+        assert tx[key].startswith("0x"), f"{prefix}'{key}' must be an 0x address"
+
+
+def poll_content_for_sender(rpc, sender_lower, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        rsp = rpc.make_request("txpool_content", [])
+        result = rsp.get("result", {})
+        pending = {k.lower(): v for k, v in result.get("pending", {}).items()}
+        if sender_lower in pending and pending[sender_lower]:
+            return result
+        time.sleep(0.1)
+    return None
+
+
+def poll_content_from(rpc, sender_addr, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        rsp = rpc.make_request("txpool_contentFrom", [sender_addr])
+        result = rsp.get("result", {})
+        if result.get("pending"):
+            return result
+        time.sleep(0.1)
+    return None
+
+
+def test_txpool_content_empty_matches_geth(custom_ethermint, txpool_geth):
+    """Empty-pool response must be {pending: {}, queued: {}} on both nodes."""
+    eth_rpc = custom_ethermint.w3.provider
+    geth_rpc = txpool_geth.w3.provider
+    w3_wait_for_new_blocks(custom_ethermint.w3, 1)
+
+    for node, rpc in [("ethermint", eth_rpc), ("geth", geth_rpc)]:
+        rsp = rpc.make_request("txpool_content", [])
+        assert "result" in rsp, f"{node} txpool_content returned an error: {rsp}"
+        result = rsp["result"]
+        assert isinstance(result, dict), f"{node}: result must be a dict"
+        keys = set(result.keys())
+        assert keys == {"pending", "queued"}, (
+            f"{node}: expected top-level keys {{pending, queued}}, got {keys}"
+        )
+        assert isinstance(result["pending"], dict), f"{node}: 'pending' must be a dict"
+        assert isinstance(result["queued"], dict), f"{node}: 'queued' must be a dict"
+        assert result["pending"] == {}, f"{node}: expected empty pending on idle node"
+        assert result["queued"] == {}, f"{node}: expected empty queued on idle node"
+
+
+def test_txpool_content_pending_schema(custom_ethermint):
+    """txpool_content pending entry must expose required RPCTransaction fields."""
+    w3 = custom_ethermint.w3
+    eth_rpc = w3.provider
+
+    signed = sign_transaction(
+        w3, {"to": ADDRS["community"], "value": 100}, key=KEYS["validator"]
+    )
+    txhash = w3.eth.send_raw_transaction(signed.raw_transaction)
+    sender = ADDRS["validator"].lower()
+
+    result = poll_content_for_sender(eth_rpc, sender)
+    assert result is not None, (
+        f"tx {Web3.to_hex(txhash)} never appeared in txpool_content pending"
+    )
+
+    pending = {k.lower(): v for k, v in result["pending"].items()}
+    nonce_map = pending[sender]
+    assert nonce_map, "nonce map for sender must be non-empty"
+
+    for nonce_str, tx in nonce_map.items():
+        assert nonce_str.isdigit(), (
+            f"nonce key must be a decimal string, got {nonce_str!r}"
+        )
+        assert_pending_rpc_tx_schema(tx, label=f"nonce={nonce_str}")
+        assert tx["from"].lower() == sender
+
+    w3.eth.wait_for_transaction_receipt(txhash, timeout=30)
+
+
+def test_txpool_content_from_filters_by_sender(custom_ethermint):
+    """txpool_contentFrom must return only the requested sender's pending txs."""
+    w3 = custom_ethermint.w3
+    eth_rpc = w3.provider
+    sender = ADDRS["validator"]
+
+    signed = sign_transaction(
+        w3, {"to": ADDRS["community"], "value": 200}, key=KEYS["validator"]
+    )
+    txhash = w3.eth.send_raw_transaction(signed.raw_transaction)
+
+    result = poll_content_from(eth_rpc, sender)
+    assert result is not None, (
+        f"tx {Web3.to_hex(txhash)} never appeared in txpool_contentFrom"
+    )
+
+    assert set(result.keys()) == {"pending", "queued"}, (
+        f"contentFrom must return {{pending, queued}}, got {set(result.keys())}"
+    )
+    assert isinstance(result["queued"], dict)
+
+    for nonce_str, tx in result["pending"].items():
+        assert nonce_str.isdigit(), (
+            f"nonce key must be a decimal string, got {nonce_str!r}"
+        )
+        assert_pending_rpc_tx_schema(tx, label=f"nonce={nonce_str}")
+        assert tx["from"].lower() == sender.lower()
+
+    w3.eth.wait_for_transaction_receipt(txhash, timeout=30)
+
+
+def test_txpool_status_and_inspect(custom_ethermint):
+    """txpool_status counts the pending tx and txpool_inspect summarizes it."""
+    w3 = custom_ethermint.w3
+    eth_rpc = w3.provider
+    sender = ADDRS["validator"].lower()
+
+    signed = sign_transaction(
+        w3, {"to": ADDRS["community"], "value": 300}, key=KEYS["validator"]
+    )
+    txhash = w3.eth.send_raw_transaction(signed.raw_transaction)
+
+    result = poll_content_for_sender(eth_rpc, sender)
+    assert result is not None, "tx never appeared in txpool_content pending"
+
+    status = eth_rpc.make_request("txpool_status", [])["result"]
+    assert set(status.keys()) == {"pending", "queued"}
+    assert int(status["pending"], 16) >= 1, "status must count the pending tx"
+    assert int(status["queued"], 16) == 0, "queued is always empty"
+
+    inspect = eth_rpc.make_request("txpool_inspect", [])["result"]
+    assert set(inspect.keys()) == {"pending", "queued"}
+    pending = {k.lower(): v for k, v in inspect["pending"].items()}
+    assert sender in pending, "inspect must list the sender"
+    for summary in pending[sender].values():
+        assert isinstance(summary, str) and "wei" in summary
+
+    w3.eth.wait_for_transaction_receipt(txhash, timeout=30)


### PR DESCRIPTION
## What

Back the `txpool` RPC namespace with the real app mempool. Previously `txpool_content`, `_inspect`, and `_status` returned empty stubs.

Stacked on #1016.

## Changes

- Wire `txpool_content`, `_inspect`, `_status`, and `_contentFrom` to live pending EVM txs via `appmempool.MempoolClient` from #1016.
- `PublicAPI.client MempoolClient`; `pending()` iterates `client.PendingTxs()` and keys by sender → nonce.
- `Status` dedupes `(sender, nonce)` slots so its count matches `Content` output.
- All txs reported as `pending`; the priority-nonce mempool has no queued split, so `queued` is always empty.
- `Inspect` (`txpool_inspect`) falls back to `GasFeeCap` when an EIP-1559 pending tx has a nil `GasPrice`.
- A nil client (apps without mempool access) reports empty pools — no panic.