### PR TITLE
fix(evm): skip rewriting eip155ChainID when unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (evm) [#1023](https://github.com/crypto-org-chain/ethermint/pull/1023) fix(evm): skip rewriting `eip155ChainID` when unchanged so per-block `WithChainID` doesn't race lock-free readers.
 * (rpc) [#1006](https://github.com/crypto-org-chain/ethermint/pull/1006) fix(rpc): disable CORS by default on the HTTP JSON-RPC server.
 * (evm) [#1020](https://github.com/crypto-org-chain/ethermint/pull/1020) fix(evm): guard SetCodeTx auth list against empty V.
 * (ante) [#1009](https://github.com/crypto-org-chain/ethermint/pull/1009) fix(ante): reject EIP-712 fallback signatures for transactions whose `TxBody` sets `timeout_timestamp`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (evm) [#1023](https://github.com/crypto-org-chain/ethermint/pull/1023) fix(evm): skip rewriting `eip155ChainID` when unchanged so per-block `WithChainID` doesn't race lock-free readers.
+* (evm) [#1023](https://github.com/crypto-org-chain/ethermint/pull/1023) fix(evm): skip rewriting eip155ChainID when unchanged.
 * (rpc) [#1006](https://github.com/crypto-org-chain/ethermint/pull/1006) fix(rpc): disable CORS by default on the HTTP JSON-RPC server.
 * (evm) [#1020](https://github.com/crypto-org-chain/ethermint/pull/1020) fix(evm): guard SetCodeTx auth list against empty V.
 * (ante) [#1009](https://github.com/crypto-org-chain/ethermint/pull/1009) fix(ante): reject EIP-712 fallback signatures for transactions whose `TxBody` sets `timeout_timestamp`.

--- a/x/evm/keeper/chain_id_test.go
+++ b/x/evm/keeper/chain_id_test.go
@@ -2,9 +2,6 @@ package keeper_test
 
 import "math/big"
 
-// TestWithChainIDStringIdempotent verifies that re-setting the same chain ID is
-// a no-op (so BeginBlock's per-block call doesn't race lock-free readers), while
-// a genuine change still panics.
 func (suite *KeeperTestSuite) TestWithChainIDStringIdempotent() {
 	suite.SetupTest()
 

--- a/x/evm/keeper/chain_id_test.go
+++ b/x/evm/keeper/chain_id_test.go
@@ -1,0 +1,26 @@
+package keeper_test
+
+import "math/big"
+
+// TestWithChainIDStringIdempotent verifies that re-setting the same chain ID is
+// a no-op (so BeginBlock's per-block call doesn't race lock-free readers), while
+// a genuine change still panics.
+func (suite *KeeperTestSuite) TestWithChainIDStringIdempotent() {
+	suite.SetupTest()
+
+	want := suite.App.EvmKeeper.ChainID()
+	suite.Require().NotNil(want)
+
+	// Re-setting the same value must not panic and must leave the ID unchanged.
+	suite.Require().NotPanics(func() {
+		suite.App.EvmKeeper.WithChainIDString("ethermint_9000-1")
+	})
+	suite.Require().Equal(0, want.Cmp(suite.App.EvmKeeper.ChainID()))
+
+	// A different value must still be rejected.
+	suite.Require().Panics(func() {
+		suite.App.EvmKeeper.WithChainIDString("ethermint_8888-1")
+	})
+	// The original ID must survive the rejected change.
+	suite.Require().Equal(0, big.NewInt(9000).Cmp(suite.App.EvmKeeper.ChainID()))
+}

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -163,8 +163,14 @@ func (k *Keeper) WithChainIDString(value string) {
 		panic(err)
 	}
 
-	if k.eip155ChainID != nil && k.eip155ChainID.Cmp(chainID) != 0 {
-		panic("chain id already set")
+	if k.eip155ChainID != nil {
+		// Chain ID is immutable once set. Reject a genuine change, but skip
+		// rewriting the same value so concurrent lock-free readers (app-side
+		// mempool admission) don't race the assignment under -race.
+		if k.eip155ChainID.Cmp(chainID) != 0 {
+			panic("chain id already set")
+		}
+		return
 	}
 
 	k.eip155ChainID = chainID

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -165,8 +165,8 @@ func (k *Keeper) WithChainIDString(value string) {
 
 	if k.eip155ChainID != nil {
 		// Chain ID is immutable once set. Reject a genuine change, but skip
-		// rewriting the same value so concurrent lock-free readers (app-side
-		// mempool admission) don't race the assignment under -race.
+		// rewriting the same value so concurrent lock-free readers don't
+		// race the assignment.
 		if k.eip155ChainID.Cmp(chainID) != 0 {
 			panic("chain id already set")
 		}


### PR DESCRIPTION
Split out from #1011.

- `WithChainIDString`: skip the redundant write when the chain ID is unchanged.
- BeginBlock calls `WithChainID` every block, rewriting `eip155ChainID` to the same value while lock-free readers (app-side mempool admission) read it — a false-positive data race under `-race`.
- A genuine chain-id change still panics.
