### PR TITLE
feat(rpc): add `eth_baseFee` JSON RPC method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
+* (rpc) [#1027](https://github.com/crypto-org-chain/ethermint/pull/1027) feat(rpc): add `eth_baseFee` JSON RPC method.
 * (rpc) [#1003](https://github.com/crypto-org-chain/ethermint/pull/1003) feat(rpc): direct app-mempool insert for EVM tx submission.
 * (deps) [#894](https://github.com/crypto-org-chain/ethermint/pull/894) feat: migrate to Cosmos SDK v0.54.3, IBC v11, CometBFT v0.39.3.
 * (ante) [#948](https://github.com/crypto-org-chain/ethermint/pull/948) fix(ante): enforce eip-1559 cost balance check even if it is not checkTx.

--- a/rpc/backend/backend.go
+++ b/rpc/backend/backend.go
@@ -111,6 +111,7 @@ type EVMBackend interface {
 	ChainConfig() *params.ChainConfig
 	GlobalMinGasPrice() (sdkmath.LegacyDec, error)
 	BaseFee(blockRes *tmrpctypes.ResultBlockResults) (*big.Int, error)
+	BaseFeeForNextBlock() (*big.Int, error)
 	CurrentHeader() (*ethtypes.Header, error)
 	PendingTransactions() ([]*sdk.Tx, error)
 	GetCoinbase() (sdk.AccAddress, error)

--- a/rpc/backend/backend.go
+++ b/rpc/backend/backend.go
@@ -111,7 +111,7 @@ type EVMBackend interface {
 	ChainConfig() *params.ChainConfig
 	GlobalMinGasPrice() (sdkmath.LegacyDec, error)
 	BaseFee(blockRes *tmrpctypes.ResultBlockResults) (*big.Int, error)
-	BaseFeeForNextBlock() (*big.Int, error)
+	NextBaseFee() (*big.Int, error)
 	CurrentHeader() (*ethtypes.Header, error)
 	PendingTransactions() ([]*sdk.Tx, error)
 	GetCoinbase() (sdk.AccAddress, error)

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -561,18 +561,9 @@ func (b *Backend) RPCBlockFromTendermintBlock(
 		b.logger.Error("failed to query consensus params", "error", err.Error())
 	}
 
-	var gasUsed uint64
-	for _, txsResult := range blockRes.TxsResults {
-		// workaround for cosmos-sdk bug. https://github.com/cosmos/cosmos-sdk/issues/10832
-		if ShouldIgnoreGasUsed(txsResult) {
-			// block gas limit has exceeded, other txs must have failed with same reason.
-			break
-		}
-		gas, err := ethermint.SafeUint64(txsResult.GetGasUsed())
-		if err != nil {
-			return nil, err
-		}
-		gasUsed += gas
+	gasUsed, err := computeGasUsed(blockRes)
+	if err != nil {
+		return nil, err
 	}
 
 	ethHeader := rpctypes.EthHeaderFromTendermint(block.Header, bloom, baseFee, validatorAccAddr)

--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -112,8 +112,8 @@ func (b *Backend) BaseFee(blockRes *cmtrpctypes.ResultBlockResults) (*big.Int, e
 	return res.BaseFee.BigInt(), nil
 }
 
-// BaseFeeForNextBlock returns the base fee of the next block.
-func (b *Backend) BaseFeeForNextBlock() (*big.Int, error) {
+// NextBaseFee returns the base fee of the next block.
+func (b *Backend) NextBaseFee() (*big.Int, error) {
 	tendermintBlock, err := b.TendermintBlockByNumber(rpctypes.EthLatestBlockNumber)
 	if err != nil {
 		return nil, err
@@ -148,16 +148,9 @@ func (b *Backend) BaseFeeForNextBlock() (*big.Int, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert gas limit: %w", err)
 	}
-	var gasUsed uint64
-	for _, txsResult := range blockRes.TxsResults {
-		if ShouldIgnoreGasUsed(txsResult) {
-			break
-		}
-		gas, err := ethermint.SafeUint64(txsResult.GetGasUsed())
-		if err != nil {
-			return nil, err
-		}
-		gasUsed += gas
+	gasUsed, err := computeGasUsed(blockRes)
+	if err != nil {
+		return nil, err
 	}
 
 	feeParams, err := b.queryClient.FeeMarket.Params(

--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -112,6 +112,75 @@ func (b *Backend) BaseFee(blockRes *cmtrpctypes.ResultBlockResults) (*big.Int, e
 	return res.BaseFee.BigInt(), nil
 }
 
+// BaseFeeForNextBlock returns the base fee of the next block.
+func (b *Backend) BaseFeeForNextBlock() (*big.Int, error) {
+	tendermintBlock, err := b.TendermintBlockByNumber(rpctypes.EthLatestBlockNumber)
+	if err != nil {
+		return nil, err
+	}
+	blockHeight := tendermintBlock.Block.Height
+
+	cfg := b.ChainConfig()
+	if cfg == nil || !cfg.IsLondon(big.NewInt(blockHeight+1)) {
+		return new(big.Int), nil
+	}
+
+	blockRes, err := b.TendermintBlockResultByNumber(&blockHeight)
+	if err != nil {
+		return nil, err
+	}
+	blockBaseFee, err := b.BaseFee(blockRes)
+	if err != nil {
+		return nil, err
+	}
+	if blockBaseFee == nil {
+		blockBaseFee = new(big.Int)
+	}
+	gasLimit, err := rpctypes.BlockMaxGasFromConsensusParams(
+		rpctypes.ContextWithHeight(blockHeight),
+		b.clientCtx,
+		blockHeight,
+	)
+	if err != nil {
+		return nil, err
+	}
+	gasLimitUint64, err := ethermint.SafeUint64(gasLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert gas limit: %w", err)
+	}
+	var gasUsed uint64
+	for _, txsResult := range blockRes.TxsResults {
+		if ShouldIgnoreGasUsed(txsResult) {
+			break
+		}
+		gas, err := ethermint.SafeUint64(txsResult.GetGasUsed())
+		if err != nil {
+			return nil, err
+		}
+		gasUsed += gas
+	}
+
+	feeParams, err := b.queryClient.FeeMarket.Params(
+		rpctypes.ContextWithHeight(blockHeight),
+		&feemarkettypes.QueryParamsRequest{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	header := ethtypes.Header{
+		Number:   big.NewInt(blockHeight),
+		BaseFee:  blockBaseFee,
+		GasLimit: gasLimitUint64,
+		GasUsed:  gasUsed,
+	}
+	nextBaseFee, err := CalcBaseFee(cfg, &header, feeParams.Params)
+	if err != nil {
+		return nil, err
+	}
+	return nextBaseFee, nil
+}
+
 // CurrentHeader returns the latest block header.
 func (b *Backend) CurrentHeader() (*ethtypes.Header, error) {
 	return b.HeaderByNumber(rpctypes.EthLatestBlockNumber)

--- a/rpc/backend/chain_info_test.go
+++ b/rpc/backend/chain_info_test.go
@@ -583,7 +583,7 @@ func (suite *BackendTestSuite) TestFeeHistory() {
 	}
 }
 
-func (suite *BackendTestSuite) TestBaseFeeForNextBlock() {
+func (suite *BackendTestSuite) TestNextBaseFee() {
 	suite.SetupTest()
 
 	const height = int64(1)
@@ -609,7 +609,7 @@ func (suite *BackendTestSuite) TestBaseFeeForNextBlock() {
 	client.On("ConsensusParams", rpc.ContextWithHeight(height), mock.AnythingOfType("*int64")).
 		Return(&tmrpctypes.ResultConsensusParams{ConsensusParams: *consensusParams}, nil)
 
-	baseFee, err := suite.backend.BaseFeeForNextBlock()
+	baseFee, err := suite.backend.NextBaseFee()
 	suite.Require().NoError(err)
 	suite.Require().Equal(big.NewInt(2), baseFee)
 }

--- a/rpc/backend/chain_info_test.go
+++ b/rpc/backend/chain_info_test.go
@@ -15,6 +15,7 @@ import (
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	tmtypes "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/mock"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/evmos/ethermint/rpc/backend/mocks"
@@ -580,6 +581,37 @@ func (suite *BackendTestSuite) TestFeeHistory() {
 			}
 		})
 	}
+}
+
+func (suite *BackendTestSuite) TestBaseFeeForNextBlock() {
+	suite.SetupTest()
+
+	const height = int64(1)
+	const (
+		gasLimit = int64(10)
+		gasUsed  = int64(6)
+	)
+
+	var header metadata.MD
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	feeMarketClient := suite.backend.queryClient.FeeMarket.(*mocks.FeeMarketQueryClient)
+	RegisterParams(queryClient, &header, height)
+	RegisterParamsWithoutHeader(queryClient, height)
+	RegisterBaseFee(queryClient, sdkmath.NewInt(1))
+	RegisterFeeMarketParams(feeMarketClient, height)
+
+	RegisterBlock(client, height, nil)
+	blockRes, _ := RegisterBlockResults(client, height)
+	blockRes.TxsResults[0].GasUsed = gasUsed
+	consensusParams := tmtypes.DefaultConsensusParams()
+	consensusParams.Block.MaxGas = gasLimit
+	client.On("ConsensusParams", rpc.ContextWithHeight(height), mock.AnythingOfType("*int64")).
+		Return(&tmrpctypes.ResultConsensusParams{ConsensusParams: *consensusParams}, nil)
+
+	baseFee, err := suite.backend.BaseFeeForNextBlock()
+	suite.Require().NoError(err)
+	suite.Require().Equal(big.NewInt(2), baseFee)
 }
 
 func (suite *BackendTestSuite) TestCurrentHeader() {

--- a/rpc/backend/utils.go
+++ b/rpc/backend/utils.go
@@ -291,6 +291,25 @@ func ShouldIgnoreGasUsed(res *abci.ExecTxResult) bool {
 	return res.GetCode() == 11 && strings.Contains(res.GetLog(), "no block gas left to run tx: out of gas")
 }
 
+// computeGasUsed sums the gas used by the transactions in the block result,
+// stopping at the first tx that should be ignored per ShouldIgnoreGasUsed
+// (cosmos-sdk bug: https://github.com/cosmos/cosmos-sdk/issues/10832).
+func computeGasUsed(blockRes *tmrpctypes.ResultBlockResults) (uint64, error) {
+	var gasUsed uint64
+	for _, txsResult := range blockRes.TxsResults {
+		if ShouldIgnoreGasUsed(txsResult) {
+			// block gas limit has exceeded, other txs must have failed with same reason.
+			break
+		}
+		gas, err := ethermint.SafeUint64(txsResult.GetGasUsed())
+		if err != nil {
+			return 0, err
+		}
+		gasUsed += gas
+	}
+	return gasUsed, nil
+}
+
 // GetLogsFromBlockResults returns the list of event logs from the tendermint block result response
 func GetLogsFromBlockResults(blockRes *tmrpctypes.ResultBlockResults) ([][]*ethtypes.Log, error) {
 	height, err := ethermint.SafeUint64(blockRes.Height)

--- a/rpc/namespaces/ethereum/eth/api.go
+++ b/rpc/namespaces/ethereum/eth/api.go
@@ -99,6 +99,7 @@ type EthereumAPI interface {
 	EstimateGas(args evmtypes.TransactionArgs, blockNrOptional *rpctypes.BlockNumber, overrides *json.RawMessage) (hexutil.Uint64, error)
 	FeeHistory(blockCount math.HexOrDecimal64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*rpctypes.FeeHistoryResult, error)
 	MaxPriorityFeePerGas() (*hexutil.Big, error)
+	BaseFee() (*hexutil.Big, error)
 	ChainId() (*hexutil.Big, error)
 
 	// Getting Uncles
@@ -364,14 +365,14 @@ func (e *PublicAPI) MaxPriorityFeePerGas() (*hexutil.Big, error) {
 // BaseFee returns the base fee of the next block in wei.
 func (e *PublicAPI) BaseFee() (*hexutil.Big, error) {
 	e.logger.Debug("eth_baseFee")
-	head, err := e.backend.CurrentHeader()
+	baseFee, err := e.backend.BaseFeeForNextBlock()
 	if err != nil {
 		return nil, err
 	}
-	if head.BaseFee == nil {
+	if baseFee == nil {
 		return (*hexutil.Big)(new(big.Int)), nil
 	}
-	return (*hexutil.Big)(head.BaseFee), nil
+	return (*hexutil.Big)(baseFee), nil
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.

--- a/rpc/namespaces/ethereum/eth/api.go
+++ b/rpc/namespaces/ethereum/eth/api.go
@@ -18,6 +18,7 @@ package eth
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 
@@ -358,6 +359,19 @@ func (e *PublicAPI) MaxPriorityFeePerGas() (*hexutil.Big, error) {
 		return nil, err
 	}
 	return (*hexutil.Big)(tipcap), nil
+}
+
+// BaseFee returns the base fee of the next block in wei.
+func (e *PublicAPI) BaseFee() (*hexutil.Big, error) {
+	e.logger.Debug("eth_baseFee")
+	head, err := e.backend.CurrentHeader()
+	if err != nil {
+		return nil, err
+	}
+	if head.BaseFee == nil {
+		return (*hexutil.Big)(new(big.Int)), nil
+	}
+	return (*hexutil.Big)(head.BaseFee), nil
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.

--- a/rpc/namespaces/ethereum/eth/api.go
+++ b/rpc/namespaces/ethereum/eth/api.go
@@ -365,7 +365,7 @@ func (e *PublicAPI) MaxPriorityFeePerGas() (*hexutil.Big, error) {
 // BaseFee returns the base fee of the next block in wei.
 func (e *PublicAPI) BaseFee() (*hexutil.Big, error) {
 	e.logger.Debug("eth_baseFee")
-	baseFee, err := e.backend.BaseFeeForNextBlock()
+	baseFee, err := e.backend.NextBaseFee()
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/namespaces/ethereum/eth/api_test.go
+++ b/rpc/namespaces/ethereum/eth/api_test.go
@@ -1,0 +1,74 @@
+package eth
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log/v2"
+
+	"github.com/evmos/ethermint/rpc/backend"
+)
+
+type testBackend struct {
+	backend.EVMBackend
+	baseFee *big.Int
+	err     error
+}
+
+func (b testBackend) BaseFeeForNextBlock() (*big.Int, error) {
+	return b.baseFee, b.err
+}
+
+func TestPublicAPIBaseFee(t *testing.T) {
+	baseFee := big.NewInt(123)
+	baseFeeErr := errors.New("base fee error")
+
+	testCases := []struct {
+		name    string
+		backend testBackend
+		expBase *big.Int
+		expErr  error
+	}{
+		{
+			name: "returns backend error",
+			backend: testBackend{
+				err: baseFeeErr,
+			},
+			expErr: baseFeeErr,
+		},
+		{
+			name: "returns zero when next base fee is nil",
+			backend: testBackend{
+				baseFee: nil,
+			},
+			expBase: new(big.Int),
+		},
+		{
+			name: "returns next block base fee",
+			backend: testBackend{
+				baseFee: baseFee,
+			},
+			expBase: baseFee,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := NewPublicAPI(log.NewNopLogger(), tc.backend)
+
+			res, err := api.BaseFee()
+			if tc.expErr != nil {
+				require.ErrorIs(t, err, tc.expErr)
+				require.Nil(t, res)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, (*hexutil.Big)(tc.expBase), res)
+		})
+	}
+}

--- a/rpc/namespaces/ethereum/eth/api_test.go
+++ b/rpc/namespaces/ethereum/eth/api_test.go
@@ -19,7 +19,7 @@ type testBackend struct {
 	err     error
 }
 
-func (b testBackend) BaseFeeForNextBlock() (*big.Int, error) {
+func (b testBackend) NextBaseFee() (*big.Int, error) {
 	return b.baseFee, b.err
 }
 


### PR DESCRIPTION
This PR implement the `eth_baseFee` JSON RPC, it returns the base fee of the next block.

spec test: https://github.com/ethereum/execution-apis/tree/main/tests/eth_baseFee