### PR TITLE
fix(rpc): reject block numbers without hex prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (rpc) [#1028](https://github.com/crypto-org-chain/ethermint/pull/1028) fix(rpc): reject block numbers without hex prefix.
 * (rpc) [#1006](https://github.com/crypto-org-chain/ethermint/pull/1006) fix(rpc): disable CORS by default on the HTTP JSON-RPC server.
 * (evm) [#1020](https://github.com/crypto-org-chain/ethermint/pull/1020) fix(evm): guard SetCodeTx auth list against empty V.
 * (ante) [#1009](https://github.com/crypto-org-chain/ethermint/pull/1009) fix(ante): reject EIP-712 fallback signatures for transactions whose `TxBody` sets `timeout_timestamp`.

--- a/rpc/types/block.go
+++ b/rpc/types/block.go
@@ -18,12 +18,10 @@ package types
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/big"
 	"strings"
 
-	"github.com/spf13/cast"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -97,9 +95,7 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	}
 
 	blckNum, err := hexutil.DecodeUint64(input)
-	if errors.Is(err, hexutil.ErrMissingPrefix) {
-		blckNum = cast.ToUint64(input)
-	} else if err != nil {
+	if err != nil {
 		return err
 	}
 	b, err := ethermint.SafeInt64(blckNum)

--- a/rpc/types/block_test.go
+++ b/rpc/types/block_test.go
@@ -5,8 +5,89 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 )
+
+func TestUnmarshalBlockNumber(t *testing.T) {
+	testCases := []struct {
+		msg         string
+		input       []byte
+		expValue    BlockNumber
+		expErr      bool
+		expErrIs    error
+		expErrValue string
+	}{
+		{
+			"hex block number",
+			[]byte("\"0x35\""),
+			BlockNumber(0x35),
+			false,
+			nil,
+			"",
+		},
+		{
+			"latest block tag",
+			[]byte("\"latest\""),
+			EthLatestBlockNumber,
+			false,
+			nil,
+			"",
+		},
+		{
+			"safe block tag",
+			[]byte("\"safe\""),
+			EthLatestBlockNumber,
+			false,
+			nil,
+			"",
+		},
+		{
+			"pending block tag",
+			[]byte("\"pending\""),
+			EthPendingBlockNumber,
+			false,
+			nil,
+			"",
+		},
+		{
+			"quoted decimal block number",
+			[]byte("\"35\""),
+			BlockNumber(0),
+			true,
+			hexutil.ErrMissingPrefix,
+			"hex string without 0x prefix",
+		},
+		{
+			"unquoted decimal block number",
+			[]byte("35"),
+			BlockNumber(0),
+			true,
+			hexutil.ErrMissingPrefix,
+			"hex string without 0x prefix",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.msg, func(t *testing.T) {
+			var bn BlockNumber
+			err := bn.UnmarshalJSON(tc.input)
+			if tc.expErr {
+				require.Error(t, err)
+				if tc.expErrIs != nil {
+					require.ErrorIs(t, err, tc.expErrIs)
+				}
+				if tc.expErrValue != "" {
+					require.EqualError(t, err, tc.expErrValue)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expValue, bn)
+		})
+	}
+}
 
 func TestUnmarshalBlockNumberOrHash(t *testing.T) {
 	bnh := new(BlockNumberOrHash)
@@ -45,6 +126,13 @@ func TestUnmarshalBlockNumberOrHash(t *testing.T) {
 			true,
 		},
 		{
+			"JSON input with decimal block number",
+			[]byte("{\"blockNumber\": \"35\"}"),
+			func() {
+			},
+			false,
+		},
+		{
 			"JSON input with both block hash and block number",
 			[]byte("{\"blockHash\": \"0x579917054e325746fda5c3ee431d73d26255bc4e10b51163862368629ae19739\", \"blockNumber\": \"0x35\"}"),
 			func() {
@@ -77,6 +165,13 @@ func TestUnmarshalBlockNumberOrHash(t *testing.T) {
 				require.Nil(t, bnh.BlockHash)
 			},
 			true,
+		},
+		{
+			"String input with decimal block number",
+			[]byte("\"35\""),
+			func() {
+			},
+			false,
 		},
 		{
 			"String input with block number safe",


### PR DESCRIPTION
align with spec: https://ethereum.github.io/execution-apis/api/methods/eth_getBlockByNumber