### PR TITLE
fix(evm): allow access list creation without requiring gas when no authorization list is provided.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (evm) [#1029](https://github.com/crypto-org-chain/ethermint/pull/1029) fix(evm): allow access list creation without requiring gas when no authorization list is provided.
 * (evm) [#1023](https://github.com/crypto-org-chain/ethermint/pull/1023) fix(evm): skip rewriting eip155ChainID when unchanged.
 * (rpc) [#1025](https://github.com/crypto-org-chain/ethermint/pull/1025) fix(rpc): propagate block-result fetch errors in `eth_getLogs` instead of returning partial logs as success.
 * (rpc) [#1006](https://github.com/crypto-org-chain/ethermint/pull/1006) fix(rpc): disable CORS by default on the HTTP JSON-RPC server.

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -1048,14 +1048,15 @@ func (k Keeper) getAccessListExcludes(ctx sdk.Context, args types.TransactionArg
 		addressesToExclude[addr] = struct{}{}
 	}
 
-	// check if enough gas was provided to cover all authorization lists
-	if args.Gas == nil {
-		return nil, errors.New("gas must be set when using authorization list")
-	}
-	maxAuthorizations := uint64(*args.Gas) / ethparams.CallNewAccountGas
-	if uint64(len(args.AuthorizationList)) > maxAuthorizations {
-		k.Logger(ctx).Error("insufficient gas to process all authorizations", "maxAuthorizations", maxAuthorizations)
-		return nil, errors.New("insufficient gas to process all authorizations")
+	if len(args.AuthorizationList) > 0 {
+		if args.Gas == nil {
+			return nil, errors.New("gas must be set when using authorization list")
+		}
+		maxAuthorizations := uint64(*args.Gas) / ethparams.CallNewAccountGas
+		if uint64(len(args.AuthorizationList)) > maxAuthorizations {
+			k.Logger(ctx).Error("insufficient gas to process all authorizations", "maxAuthorizations", maxAuthorizations)
+			return nil, errors.New("insufficient gas to process all authorizations")
+		}
 	}
 
 	for _, auth := range args.AuthorizationList {

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -2814,6 +2814,32 @@ func (suite *GRPCServerTestSuiteSuite) TestCreateAccessList() {
 	}
 }
 
+func (suite *GRPCServerTestSuiteSuite) TestCreateAccessListWithoutGas() {
+	suite.App.EvmKeeper.SetBalance(suite.Ctx, suite.Address, *uint256.NewInt(1000000000000000000), types.DefaultEVMDenom)
+
+	to := tests.GenerateAddress()
+	value := (*hexutil.Big)(big.NewInt(10))
+	args, err := json.Marshal(&types.TransactionArgs{
+		From:  &suite.Address,
+		To:    &to,
+		Value: value,
+	})
+	suite.Require().NoError(err)
+
+	res, err := suite.App.EvmKeeper.CreateAccessList(suite.Ctx, &types.EthCallRequest{
+		Args:   args,
+		GasCap: uint64(config.DefaultGasCap),
+	})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+
+	var result types.AccessListResult
+	suite.Require().NoError(json.Unmarshal(res.Data, &result))
+	suite.Require().Empty(result.AccessList)
+	suite.Require().NotZero(uint64(result.GasUsed))
+	suite.Require().Empty(result.Error)
+}
+
 func (suite *GRPCServerTestSuiteSuite) TestCreateAccessList_VmError() {
 	contractAddr := suite.deployTestContract(suite.Address)
 	suite.Commit(suite.T())


### PR DESCRIPTION
https://github.com/ethereum/execution-apis/blob/main/tests/eth_createAccessList/create-al-value-transfer.io