### PR TITLE
fix(rpc): prevent nil-pointer panic in eth_getLogs on zero block hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (rpc) [#1039](https://github.com/crypto-org-chain/ethermint/pull/1039) fix(rpc): prevent nil-pointer panic in `eth_getLogs`/`eth_getFilterLogs` when a zero block hash is supplied.
 * (evm) [#1029](https://github.com/crypto-org-chain/ethermint/pull/1029) fix(evm): allow access list creation without requiring gas when no authorization list is provided.
 * (rpc) [#1030](https://github.com/crypto-org-chain/ethermint/pull/1030) fix(rpc): align eth_getStorageAt storage key parsing.
 * (evm) [#1023](https://github.com/crypto-org-chain/ethermint/pull/1023) fix(evm): skip rewriting eip155ChainID when unchanged.

--- a/rpc/namespaces/ethereum/eth/filters/filters.go
+++ b/rpc/namespaces/ethereum/eth/filters/filters.go
@@ -104,8 +104,8 @@ func newFilter(logger log.Logger, backend Backend, criteria filters.FilterCriter
 // Logs searches the blockchain for matching log entries, returning all from the
 // first block that contains matches, updating the start of the filter accordingly.
 func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*ethtypes.Log, error) {
-	// If we're doing singleton block filtering, execute and return
-	if f.criteria.BlockHash != nil && *f.criteria.BlockHash != (common.Hash{}) {
+	// In case the blockhash is set, we fetch the block and return the logs.
+	if f.criteria.BlockHash != nil {
 		resBlock, err := f.backend.TendermintBlockByHash(*f.criteria.BlockHash)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch header by hash %s: %w", f.criteria.BlockHash, err)
@@ -148,6 +148,13 @@ func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*eth
 	}
 
 	head := header.Number.Int64()
+	// The range path assumes non-nil bounds.
+	if f.criteria.FromBlock == nil {
+		f.criteria.FromBlock = big.NewInt(head)
+	}
+	if f.criteria.ToBlock == nil {
+		f.criteria.ToBlock = big.NewInt(head)
+	}
 	if f.criteria.FromBlock.Int64() < 0 {
 		f.criteria.FromBlock = big.NewInt(head)
 	} else if f.criteria.FromBlock.Int64() == 0 {

--- a/rpc/namespaces/ethereum/eth/filters/filters_test.go
+++ b/rpc/namespaces/ethereum/eth/filters/filters_test.go
@@ -218,6 +218,22 @@ func TestGetLogs_BlockHashNotFound(t *testing.T) {
 	require.Nil(t, logs)
 }
 
+func TestGetLogs_ZeroBlockHashDoesNotPanic(t *testing.T) {
+	api := &PublicFilterAPI{
+		logger:  logv2.NewNopLogger(),
+		backend: &stubBackend{head: 100},
+	}
+
+	zeroHash := common.Hash{}
+	crit := gethfilters.FilterCriteria{BlockHash: &zeroHash}
+
+	require.NotPanics(t, func() {
+		logs, err := api.GetLogs(context.Background(), crit)
+		require.Error(t, err)
+		require.Nil(t, logs)
+	})
+}
+
 func TestGetLogs_BlockHashFound(t *testing.T) {
 	const height = int64(10)
 	logAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

`GetLogs`/`GetFilterLogs` (`api.go`) route any **non-nil** `BlockHash` to `NewBlockFilter`, which leaves `FromBlock`/`ToBlock` nil. But `Filter.Logs` (`filters.go:108`) only took the singleton block-hash branch when the hash was **also non-zero**. A request with a zero hash (`{"blockHash":"0x00…00"}`) therefore fell through to the range path and dereferenced the nil `FromBlock` at `filters.go:151`, panicking. go-ethereum's RPC layer recovers per-call panics into an error response, so the practical impact is a logged panic + error per request.

## Fix

* `Filter.Logs` now takes the block-hash branch for any non-nil `BlockHash`, matching the
  routing in `api.go` — a zero hash returns a clean `unknown block` error.
* Added a defense-in-depth nil-guard on `FromBlock`/`ToBlock` in the range path.
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
