### PR TITLE
fix(rpc): cap eth_feeHistory rewardPercentiles length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (rpc) [#1040](https://github.com/crypto-org-chain/ethermint/pull/1040) fix(rpc): cap `eth_feeHistory` `rewardPercentiles` length to bound reward-matrix allocation.
 * (evm) [#1029](https://github.com/crypto-org-chain/ethermint/pull/1029) fix(evm): allow access list creation without requiring gas when no authorization list is provided.
 * (rpc) [#1030](https://github.com/crypto-org-chain/ethermint/pull/1030) fix(rpc): align eth_getStorageAt storage key parsing.
 * (evm) [#1023](https://github.com/crypto-org-chain/ethermint/pull/1023) fix(evm): skip rewriting eip155ChainID when unchanged.

--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -229,9 +229,14 @@ func (b *Backend) GetCoinbase() (sdk.AccAddress, error) {
 }
 
 var (
-	errInvalidPercentile = fmt.Errorf("invalid reward percentile")
-	errRequestBeyondHead = fmt.Errorf("request beyond head block")
+	errInvalidPercentile  = fmt.Errorf("invalid reward percentile")
+	errRequestBeyondHead  = fmt.Errorf("request beyond head block")
+	errTooManyPercentiles = fmt.Errorf("too many reward percentiles")
 )
+
+// maxFeeHistoryRewardPercentiles bounds the length of the rewardPercentiles
+// array accepted by eth_feeHistory.
+const maxFeeHistoryRewardPercentiles = 100
 
 // FeeHistory returns data relevant for fee estimation based on the specified range of blocks.
 func (b *Backend) FeeHistory(
@@ -239,6 +244,9 @@ func (b *Backend) FeeHistory(
 	lastBlock rpc.BlockNumber, // the block to start search , to oldest
 	rewardPercentiles []float64, // percentiles to fetch reward
 ) (*rpctypes.FeeHistoryResult, error) {
+	if len(rewardPercentiles) > maxFeeHistoryRewardPercentiles {
+		return nil, fmt.Errorf("%w: %d > %d", errTooManyPercentiles, len(rewardPercentiles), maxFeeHistoryRewardPercentiles)
+	}
 	for i, p := range rewardPercentiles {
 		if p < 0 || p > 100 {
 			return nil, fmt.Errorf("%w: %f", errInvalidPercentile, p)

--- a/rpc/backend/chain_info_test.go
+++ b/rpc/backend/chain_info_test.go
@@ -583,6 +583,21 @@ func (suite *BackendTestSuite) TestFeeHistory() {
 	}
 }
 
+func (suite *BackendTestSuite) TestFeeHistoryRewardPercentileCap() {
+	suite.SetupTest()
+
+	// Build a valid (in-range, non-decreasing) percentile slice that exceeds
+	// the cap. It must be rejected purely on length, before any backend query.
+	percentiles := make([]float64, maxFeeHistoryRewardPercentiles+1)
+	for i := range percentiles {
+		percentiles[i] = 50
+	}
+
+	_, err := suite.backend.FeeHistory(1, ethrpc.BlockNumber(1), percentiles)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, errTooManyPercentiles)
+}
+
 func (suite *BackendTestSuite) TestNextBaseFee() {
 	suite.SetupTest()
 


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

`blockCount` is bounded by `FeeHistoryCap` (default 100), but the length of the
`rewardPercentiles` array was never bounded. Validation only required values in `[0,100]` and
non-decreasing order — duplicates are explicitly allowed. The code then allocates a
`blocks × len(percentiles)` matrix of `*big.Int` and runs an O(percentiles) loop per block, so a
long duplicated percentile array (e.g. `[50,50,50,…]`) amplifies cheaply near the RPC body-size
ceiling.


______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
