### PR TITLE
fix(rpc): cap WebSocket eth_subscribe subscriptions per connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (rpc) [#1041](https://github.com/crypto-org-chain/ethermint/pull/1041) fix(rpc): enforce a per-connection cap on WebSocket `eth_subscribe` subscriptions.
 * (evm) [#1029](https://github.com/crypto-org-chain/ethermint/pull/1029) fix(evm): allow access list creation without requiring gas when no authorization list is provided.
 * (rpc) [#1030](https://github.com/crypto-org-chain/ethermint/pull/1030) fix(rpc): align eth_getStorageAt storage key parsing.
 * (evm) [#1023](https://github.com/crypto-org-chain/ethermint/pull/1023) fix(evm): skip rewriting eip155ChainID when unchanged.

--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -51,6 +51,11 @@ const (
 	methodEthUnsubscribe = "eth_unsubscribe"
 )
 
+// maxSubscriptionsPerConn bounds the number of concurrently active
+// eth_subscribe subscriptions on a single WebSocket connection. Each
+// subscription holds a per-connection entry and a streaming goroutine
+const maxSubscriptionsPerConn = 500
+
 type WebsocketsServer interface {
 	Start()
 }
@@ -291,6 +296,12 @@ func (s *websocketsServer) readLoop(wsConn *wsConn) {
 		case methodEthSubscribe:
 			params, ok := s.getParamsAndCheckValid(msg, wsConn)
 			if !ok {
+				continue
+			}
+
+			if len(subscriptions) >= maxSubscriptionsPerConn {
+				s.sendErrResponseWithID(wsConn, connID, fmt.Sprintf(
+					"subscription limit reached: max %d active subscriptions per connection", maxSubscriptionsPerConn))
 				continue
 			}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

`RPCFilterCap` bounds HTTP filters, but WebSocket `eth_subscribe` does not go through that map.
Each subscribe stored a per-connection entry and spawned a streaming goroutine
(`newHeads` / `logs` / `pendingTransactions`) with no limit. An allowed-origin client could open
one WS connection and issue unbounded `eth_subscribe` calls, spawning unbounded goroutines and
streams until node memory is exhausted.
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
