### PR TITLE
fix(deps): bump Go to 1.25.11 to resolve stdlib vulnerabilities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/dependabot-update-all.yml
+++ b/.github/workflows/dependabot-update-all.yml
@@ -28,7 +28,7 @@ jobs:
           token: "${{ steps.app-token.outputs.token }}"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           check-latest: true
       - name: Extract updated dependency
         id: deps

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Setup Go"
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           check-latest: true
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v5

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - name: release dry run
         run: make release-dry-run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       # Required: setup-go, for all versions v3.0.0+ of golangci-lint
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6.1.2
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6.1.2
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6.1.2
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6.1.2
@@ -177,7 +177,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6.1.2
@@ -197,7 +197,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6.1.2
@@ -217,7 +217,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
           check-latest: true
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (deps) [#1037](https://github.com/crypto-org-chain/ethermint/pull/1037) fix(deps): bump Go toolchain to 1.25.11 to resolve `net/textproto` (GO-2026-5039) and `crypto/x509` (GO-2026-5037) standard-library vulnerabilities.
+* (deps) [#1043](https://github.com/crypto-org-chain/ethermint/pull/1043) ffix(deps): bump Go to 1.25.11 to resolve stdlib vulnerabilities
 * (evm) [#1029](https://github.com/crypto-org-chain/ethermint/pull/1029) fix(evm): allow access list creation without requiring gas when no authorization list is provided.
 * (rpc) [#1030](https://github.com/crypto-org-chain/ethermint/pull/1030) fix(rpc): align eth_getStorageAt storage key parsing.
 * (evm) [#1023](https://github.com/crypto-org-chain/ethermint/pull/1023) fix(evm): skip rewriting eip155ChainID when unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (deps) [#1043](https://github.com/crypto-org-chain/ethermint/pull/1043) ffix(deps): bump Go to 1.25.10 to resolve stdlib vulnerabilities
+* (deps) [#1043](https://github.com/crypto-org-chain/ethermint/pull/1043) ffix(deps): bump Go to 1.25.11 to resolve stdlib vulnerabilities
 * (server) [#1045](https://github.com/crypto-org-chain/ethermint/pull/1045) fix(server): fix JSON-RPC goroutine leak and surface WS startup errors.
 * (rpc) [#1041](https://github.com/crypto-org-chain/ethermint/pull/1041) fix(rpc): enforce a per-connection cap on WebSocket `eth_subscribe` subscriptions.
 * (rpc) [#1040](https://github.com/crypto-org-chain/ethermint/pull/1040) fix(rpc): cap `eth_feeHistory` `rewardPercentiles` length to bound reward-matrix allocation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (deps) [#1037](https://github.com/crypto-org-chain/ethermint/pull/1037) fix(deps): bump Go toolchain to 1.25.11 to resolve `net/textproto` (GO-2026-5039) and `crypto/x509` (GO-2026-5037) standard-library vulnerabilities.
 * (evm) [#1029](https://github.com/crypto-org-chain/ethermint/pull/1029) fix(evm): allow access list creation without requiring gas when no authorization list is provided.
 * (rpc) [#1030](https://github.com/crypto-org-chain/ethermint/pull/1030) fix(rpc): align eth_getStorageAt storage key parsing.
 * (evm) [#1023](https://github.com/crypto-org-chain/ethermint/pull/1023) fix(evm): skip rewriting eip155ChainID when unchanged.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ parent:
 
 Ethermint is a scalable and interoperable Ethereum library, built on Proof-of-Stake with fast-finality using the [Cosmos SDK](https://github.com/cosmos/cosmos-sdk/) which runs on top of [Tendermint Core](https://github.com/tendermint/tendermint) consensus engine.
 
-**Note**: Requires [Go 1.25.10+](https://golang.org/dl/)
+**Note**: Requires [Go 1.25.11+](https://golang.org/dl/)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ parent:
 
 Ethermint is a scalable and interoperable Ethereum library, built on Proof-of-Stake with fast-finality using the [Cosmos SDK](https://github.com/cosmos/cosmos-sdk/) which runs on top of [Tendermint Core](https://github.com/tendermint/tendermint) consensus engine.
 
-**Note**: Requires [Go 1.25.8+](https://golang.org/dl/)
+**Note**: Requires [Go 1.25.10+](https://golang.org/dl/)
 
 ## Installation
 

--- a/flake.lock
+++ b/flake.lock
@@ -41,17 +41,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775811116,
-        "narHash": "sha256-t+HZK42pB6N+i5RGbuy7Xluez/VvWbembBdvzsc23Ss=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/54170c54449ea4d6725efd30d719c5e505f1c10e";
+    nixpkgs.url = "github:NixOS/nixpkgs/0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c";
     flake-utils.url = "github:numtide/flake-utils";
     poetry2nix = {
       url = "github:nix-community/poetry2nix";

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evmos/ethermint
 
-go 1.25.9
+go 1.25.10
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evmos/ethermint
 
-go 1.25.10
+go 1.25.11
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/networks/local/ethermintnode/Dockerfile
+++ b/networks/local/ethermintnode/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8 as build-env
+FROM golang:1.25.11 as build-env
 
 # Install minimum necessary dependencies
 ENV PACKAGES curl make git libc-dev bash gcc
@@ -15,7 +15,7 @@ COPY . .
 RUN make build-linux
 
 # Final image
-FROM golang:1.25.8 as final
+FROM golang:1.25.11 as final
 
 WORKDIR /
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -82,7 +82,7 @@ import sources.nixpkgs {
     (import ./build_overlay.nix)
     (final: super: {
       flake-compat = import sources.flake-compat;
-      # nixpkgs 25.11 already aliases go = go_1_25 (1.25.9) and buildGoModule = buildGo125Module
+      # nixpkgs 25.11 already aliases go = go_1_25 (1.25.10) and buildGoModule = buildGo125Module
       go-ethereum = final.callPackage ./go-ethereum.nix {
         # Skip darwin-specific dependencies to avoid apple_sdk_11_0 errors in nixpkgs 25.11
         libobjc = null;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,6 +17,15 @@ let
       substituteInPlace vendor/pyproject.nix/lib/pep599.nix \
         --replace 'manyLinuxTargetMachines = {' \
                   'manyLinuxTargetMachines = { riscv64 = "riscv64";'
+      # nixpkgs 26.05 dropped the `tomli` argument from the `build` and
+      # `pyproject-hooks` python modules (Python 3.11+ ships tomllib), so these
+      # poetry2nix bootstrap overrides fail with "called with unexpected argument
+      # 'tomli'". Drop tomli from those overrides.
+      substituteInPlace overrides/default.nix \
+        --replace-fail 'inherit (final) buildPythonPackage flit-core packaging pyproject-hooks tomli;' \
+                       'inherit (final) buildPythonPackage flit-core packaging pyproject-hooks;' \
+        --replace-fail 'inherit (final) buildPythonPackage flit-core tomli;' \
+                       'inherit (final) buildPythonPackage flit-core;'
     '';
   };
   # Patch gomod2nix's symlink builder to handle split-module monorepos where

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -80,18 +80,26 @@ in
 import sources.nixpkgs {
   overlays = [
     (import ./build_overlay.nix)
+    # nixpkgs 26.05 defaults `go` to go_1_26 and `buildGoModule` to buildGo126Module.
+    # Pin both back to the go 1.25 series (go_1_25 = 1.25.11 in 26.05) so go-ethereum,
+    # golangci-lint and cosmovisor keep building with the same toolchain as ethermintd
+    # (which pins go_1_25 explicitly in ../default.nix).
+    (final: _prev: {
+      go = final.go_1_25;
+      buildGoModule = final.buildGo125Module;
+    })
     (final: super: {
       flake-compat = import sources.flake-compat;
-      # nixpkgs 25.11 already aliases go = go_1_25 (1.25.10) and buildGoModule = buildGo125Module
+      # go/buildGoModule are pinned to the 1.25 series (1.25.11) by the overlay above
       go-ethereum = final.callPackage ./go-ethereum.nix {
-        # Skip darwin-specific dependencies to avoid apple_sdk_11_0 errors in nixpkgs 25.11
+        # Skip darwin-specific dependencies to avoid apple_sdk_11_0 errors in nixpkgs 26.05
         libobjc = null;
         IOKit = null;
       };
       golangci-lint = final.callPackage ./golangci-lint.nix { };
     }) # update to a version that supports eip-1559
     (import "${patchedPoetry2nix}/overlay.nix")
-    # Fix poetry2nix compatibility with nixpkgs 25.11 - override fetchCargoTarball usage
+    # Fix poetry2nix compatibility with nixpkgs 26.05 - override fetchCargoTarball usage
     (final: prev: {
       poetry2nix = prev.poetry2nix.overrideScope (
         p2nFinal: p2nPrev: {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
-        "sha256": "1hp1ddh41wrqxgrnfa79nsv7gzlbpwcqsijx7jw5b33wvk5ah5gb",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "sha256": "0ln4yw7z3g9lb0x081hc0pd2j1wsx2qqf6bgmwwvdbkcl4bcy1dp",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d7a713c0b7e47c908258e71cba7a2d77cc8d71d5.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b6018f87da91d19d0ab4cf979885689b469cdd41.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -48,15 +48,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-25.11",
+        "branch": "nixos-26.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
-        "sha256": "0ln4yw7z3g9lb0x081hc0pd2j1wsx2qqf6bgmwwvdbkcl4bcy1dp",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
+        "sha256": "07lxgdh4cgvv4bl964vq0y2y6dsw44nlg9hgmhxsxajbsphk44nk",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b6018f87da91d19d0ab4cf979885689b469cdd41.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
govulncheck flagged two standard-library vulnerabilities:
- GO-2026-5039 (net/textproto) — reached via client.KeyCommands
- GO-2026-5037 (crypto/x509)   — reached via the websocket upgrader and
  x509 hostname error handling

Both are fixed in go1.25.11. Since govulncheck derives the stdlib version from the toolchain that runs it, bumping the pinned Go version across CI workflows (and the local devnet Dockerfile) clears both findings.

The remaining GO-2026-4479 (github.com/pion/dtls/v2, pulled transitively via go-ethereum p2p → pion/stun/v2) has no upstream v2 fix and is already allowlisted in the dependency-review workflow.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
