### PR TITLE
fix(rpc): exclude Cosmos gas from transaction receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (rpc) [#1063](https://github.com/crypto-org-chain/ethermint/pull/1063) fix(rpc): exclude preceding Cosmos transaction gas from Ethereum receipt `cumulativeGasUsed`.
 * (evm) [#1056](https://github.com/crypto-org-chain/ethermint/pull/1056) enforce EIP-7825 per-transaction gas limit cap (`MaxTxGas`) once Osaka activates.
 * (deps) [#1043](https://github.com/crypto-org-chain/ethermint/pull/1043) ffix(deps): bump Go to 1.25.11 to resolve stdlib vulnerabilities
 * (server) [#1045](https://github.com/crypto-org-chain/ethermint/pull/1045) fix(server): fix JSON-RPC goroutine leak and surface WS startup errors.

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -239,13 +239,12 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash, block *tmrpctypes.Resu
 		return nil, nil
 	}
 
-	entries, err := b.collectReceiptEntriesFromBlock(block, blockResults, &hash)
+	receipt, err := b.buildReceiptFromBlock(block, blockResults, hash)
 	if err != nil {
 		return nil, err
 	}
-	entry := findReceiptEntry(entries, hash)
-	if entry != nil {
-		return b.buildReceiptDirect(block, blockResults, entry.txResult, entry.ethMsg)
+	if receipt != nil {
+		return receipt, nil
 	}
 	b.logger.Debug("tx not found in block", "hash", hash, "height", block.Block.Height)
 	return nil, nil
@@ -273,13 +272,12 @@ func (b *Backend) getTransactionReceiptByIndexer(hash common.Hash) (map[string]i
 		b.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
 		return nil, nil
 	}
-	entries, err := b.collectReceiptEntriesFromBlock(block, blockResults, &hash)
+	receipt, err := b.buildReceiptFromBlock(block, blockResults, hash)
 	if err != nil {
 		return nil, err
 	}
-	entry := findReceiptEntry(entries, hash)
-	if entry != nil {
-		return b.buildReceiptDirect(block, blockResults, entry.txResult, entry.ethMsg)
+	if receipt != nil {
+		return receipt, nil
 	}
 	b.logger.Debug("tx not found in indexed block", "hash", hash, "height", res.Height)
 	return nil, nil
@@ -291,13 +289,21 @@ type receiptEntry struct {
 	ethMsg   *evmtypes.MsgEthereumTx
 }
 
-func findReceiptEntry(entries []receiptEntry, hash common.Hash) *receiptEntry {
+func (b *Backend) buildReceiptFromBlock(
+	block *tmrpctypes.ResultBlock,
+	blockResults *tmrpctypes.ResultBlockResults,
+	hash common.Hash,
+) (map[string]interface{}, error) {
+	entries, err := b.collectReceiptEntriesFromBlock(block, blockResults, &hash)
+	if err != nil {
+		return nil, err
+	}
 	for i := range entries {
 		if entries[i].hash == hash {
-			return &entries[i]
+			return b.buildReceiptDirect(block, blockResults, entries[i].txResult, entries[i].ethMsg)
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // collectReceiptEntriesFromBlock walks the block and builds eth receipt entries.

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -279,7 +279,7 @@ func (b *Backend) getTransactionReceiptByIndexer(hash common.Hash) (map[string]i
 	if receipt != nil {
 		return receipt, nil
 	}
-	b.logger.Debug("tx not found in indexed block", "hash", hash, "height", res.Height)
+	b.logger.Error("tx not found in indexed block", "hash", hash, "height", res.Height)
 	return nil, nil
 }
 

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -239,21 +239,20 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash, block *tmrpctypes.Resu
 		return nil, nil
 	}
 
-	input, err := b.collectReceiptEntriesFromBlock(block, blockResults, &hash)
+	entries, err := b.collectReceiptEntriesFromBlock(block, blockResults, &hash)
 	if err != nil {
 		return nil, err
 	}
-	for i := range input {
-		if input[i].hash == hash {
-			return b.buildReceiptDirect(block, blockResults, input[i].txResult, input[i].ethMsg)
-		}
+	entry := findReceiptEntry(entries, hash)
+	if entry != nil {
+		return b.buildReceiptDirect(block, blockResults, entry.txResult, entry.ethMsg)
 	}
 	b.logger.Debug("tx not found in block", "hash", hash, "height", block.Block.Height)
 	return nil, nil
 }
 
-// getTransactionReceiptByIndexer resolves the tx via the KV indexer and
-// assembles the receipt, folding prior cosmos tx gas into cumulativeGasUsed.
+// getTransactionReceiptByIndexer resolves the tx's block via the KV indexer,
+// then rebuilds the receipt using the block-wide Ethereum receipt sequence.
 func (b *Backend) getTransactionReceiptByIndexer(hash common.Hash) (map[string]interface{}, error) {
 	res, err := b.GetTxByEthHash(hash)
 	if err != nil {
@@ -274,41 +273,31 @@ func (b *Backend) getTransactionReceiptByIndexer(hash common.Hash) (map[string]i
 		b.logger.Debug("failed to retrieve block results", "height", res.Height, "error", err.Error())
 		return nil, nil
 	}
-	if int(res.TxIndex) >= len(block.Block.Txs) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range (block has %d txs)", res.TxIndex, len(block.Block.Txs))
-	}
-	tx, err := b.clientCtx.TxConfig.TxDecoder()(block.Block.Txs[res.TxIndex])
+	entries, err := b.collectReceiptEntriesFromBlock(block, blockResults, &hash)
 	if err != nil {
-		return nil, errorsmod.Wrapf(errortypes.ErrTxDecode, "failed to decode tx: %v", err)
+		return nil, err
 	}
-	msgs := tx.GetMsgs()
-	if int(res.MsgIndex) >= len(msgs) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "msg index %d out of range (tx has %d msgs)", res.MsgIndex, len(msgs))
+	entry := findReceiptEntry(entries, hash)
+	if entry != nil {
+		return b.buildReceiptDirect(block, blockResults, entry.txResult, entry.ethMsg)
 	}
-	ethMsg, ok := msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
-	if !ok {
-		return nil, errorsmod.Wrapf(errortypes.ErrInvalidType, "msg at index %d is not MsgEthereumTx (got %T)", res.MsgIndex, msgs[res.MsgIndex])
-	}
-
-	if int(res.TxIndex) >= len(blockResults.TxsResults) {
-		return nil, errorsmod.Wrapf(errortypes.ErrLogic, "tx index %d out of range for block results (%d txs)", res.TxIndex, len(blockResults.TxsResults))
-	}
-	var priorGas uint64
-	for _, txResult := range blockResults.TxsResults[0:res.TxIndex] {
-		gas, err := ethermint.SafeUint64(txResult.GasUsed)
-		if err != nil {
-			return nil, err
-		}
-		priorGas += gas
-	}
-	res.CumulativeGasUsed += priorGas
-	return b.buildReceiptDirect(block, blockResults, res, ethMsg)
+	b.logger.Debug("tx not found in indexed block", "hash", hash, "height", res.Height)
+	return nil, nil
 }
 
 type receiptEntry struct {
 	hash     common.Hash
 	txResult *ethermint.TxResult
 	ethMsg   *evmtypes.MsgEthereumTx
+}
+
+func findReceiptEntry(entries []receiptEntry, hash common.Hash) *receiptEntry {
+	for i := range entries {
+		if entries[i].hash == hash {
+			return &entries[i]
+		}
+	}
+	return nil
 }
 
 // collectReceiptEntriesFromBlock walks the block and builds eth receipt entries.
@@ -325,6 +314,8 @@ func (b *Backend) collectReceiptEntriesFromBlock(
 	entries := make([]receiptEntry, 0, len(block.Block.Txs))
 	// Keep eth tx index assignment consistent with KV indexer.
 	var ethTxIndex int32
+	// Ethereum receipts accumulate gas across Ethereum messages only, excluding
+	// gas consumed by non-EVM Cosmos transactions in the same block.
 	var cumulativeGasUsed uint64
 	for txIndex, txBz := range block.Block.Txs {
 		if txIndex >= len(blockResults.TxsResults) {

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -886,7 +886,7 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 	}
 }
 
-func (suite *BackendTestSuite) TestGetTransactionReceipt_IgnoresPriorCosmosTxGas() {
+func (suite *BackendTestSuite) TestGetTransactionReceipt_IgnoresInterleavedCosmosTxGas() {
 	bankTxBuilder := suite.backend.clientCtx.TxConfig.NewTxBuilder()
 	err := bankTxBuilder.SetMsgs(&banktypes.MsgSend{
 		FromAddress: suite.acc.String(),
@@ -897,20 +897,32 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt_IgnoresPriorCosmosTxGas
 
 	bankTxBz, err := suite.backend.clientCtx.TxConfig.TxEncoder()(bankTxBuilder.GetTx())
 	suite.Require().NoError(err)
-	ethMsg, ethTxBz := suite.buildEthereumTxWithNonceAndGas(0, 100000)
+	firstEthMsg, firstEthTxBz := suite.buildEthereumTxWithNonceAndGas(0, 100000)
+	secondEthMsg, secondEthTxBz := suite.buildEthereumTxWithNonceAndGas(1, 100000)
 
 	blockResults := &tmrpctypes.ResultBlockResults{
 		Height: 1,
 		TxsResults: []*abci.ExecTxResult{
-			{Code: 0, GasUsed: 50000},
 			{
 				Code:    0,
 				GasUsed: 21000,
 				Events: []abci.Event{{
 					Type: evmtypes.EventTypeEthereumTx,
 					Attributes: []abci.EventAttribute{
-						{Key: evmtypes.AttributeKeyEthereumTxHash, Value: ethMsg.Hash().Hex()},
+						{Key: evmtypes.AttributeKeyEthereumTxHash, Value: firstEthMsg.Hash().Hex()},
 						{Key: evmtypes.AttributeKeyTxIndex, Value: "0"},
+					},
+				}},
+			},
+			{Code: 0, GasUsed: 50000},
+			{
+				Code:    0,
+				GasUsed: 30000,
+				Events: []abci.Event{{
+					Type: evmtypes.EventTypeEthereumTx,
+					Attributes: []abci.EventAttribute{
+						{Key: evmtypes.AttributeKeyEthereumTxHash, Value: secondEthMsg.Hash().Hex()},
+						{Key: evmtypes.AttributeKeyTxIndex, Value: "1"},
 					},
 				}},
 			},
@@ -922,23 +934,25 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt_IgnoresPriorCosmosTxGas
 	var header metadata.MD
 	RegisterParamsWithoutHeader(queryClient, 1)
 	RegisterParams(queryClient, &header, 1)
-	_, err = RegisterBlockMultipleTxs(client, 1, []types.Tx{bankTxBz, ethTxBz})
+	blockTxs := []types.Tx{firstEthTxBz, bankTxBz, secondEthTxBz}
+	_, err = RegisterBlockMultipleTxs(client, 1, blockTxs)
 	suite.Require().NoError(err)
 	client.On("BlockResults", rpctypes.ContextWithHeight(1), mock.AnythingOfType("*int64")).Return(blockResults, nil)
 
 	suite.backend.indexer = indexer.NewKVIndexer(dbm.NewMemDB(), tmlog.NewNopLogger(), suite.backend.clientCtx)
-	block := types.MakeBlock(1, []types.Tx{bankTxBz, ethTxBz}, nil, nil)
+	block := types.MakeBlock(1, blockTxs, nil, nil)
 	suite.Require().NoError(suite.backend.indexer.IndexBlock(block, blockResults.TxsResults))
 
-	receiptByHash, err := suite.backend.GetTransactionReceipt(ethMsg.Hash(), nil)
+	receiptByHash, err := suite.backend.GetTransactionReceipt(secondEthMsg.Hash(), nil)
 	suite.Require().NoError(err)
-	suite.Require().Equal(hexutil.Uint64(21000), receiptByHash["cumulativeGasUsed"])
+	suite.Require().Equal(hexutil.Uint64(51000), receiptByHash["cumulativeGasUsed"])
 
 	blockNum := rpctypes.BlockNumber(1)
 	blockReceipts, err := suite.backend.GetBlockReceipts(rpctypes.BlockNumberOrHash{BlockNumber: &blockNum})
 	suite.Require().NoError(err)
-	suite.Require().Len(blockReceipts, 1)
-	suite.Require().Equal(blockReceipts[0]["cumulativeGasUsed"], receiptByHash["cumulativeGasUsed"])
+	suite.Require().Len(blockReceipts, 2)
+	suite.Require().Equal(hexutil.Uint64(21000), blockReceipts[0]["cumulativeGasUsed"])
+	suite.Require().Equal(receiptByHash["cumulativeGasUsed"], blockReceipts[1]["cumulativeGasUsed"])
 }
 
 // TestGetTransactionReceipt_BlockScopedWhenIndexerOverwritten verifies that when

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -883,6 +884,61 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 			}
 		})
 	}
+}
+
+func (suite *BackendTestSuite) TestGetTransactionReceipt_IgnoresPriorCosmosTxGas() {
+	bankTxBuilder := suite.backend.clientCtx.TxConfig.NewTxBuilder()
+	err := bankTxBuilder.SetMsgs(&banktypes.MsgSend{
+		FromAddress: suite.acc.String(),
+		ToAddress:   sdk.AccAddress(make([]byte, 20)).String(),
+		Amount:      sdk.NewCoins(sdk.NewInt64Coin("aphoton", 1)),
+	})
+	suite.Require().NoError(err)
+
+	bankTxBz, err := suite.backend.clientCtx.TxConfig.TxEncoder()(bankTxBuilder.GetTx())
+	suite.Require().NoError(err)
+	ethMsg, ethTxBz := suite.buildEthereumTxWithNonceAndGas(0, 100000)
+
+	blockResults := &tmrpctypes.ResultBlockResults{
+		Height: 1,
+		TxsResults: []*abci.ExecTxResult{
+			{Code: 0, GasUsed: 50000},
+			{
+				Code:    0,
+				GasUsed: 21000,
+				Events: []abci.Event{{
+					Type: evmtypes.EventTypeEthereumTx,
+					Attributes: []abci.EventAttribute{
+						{Key: evmtypes.AttributeKeyEthereumTxHash, Value: ethMsg.Hash().Hex()},
+						{Key: evmtypes.AttributeKeyTxIndex, Value: "0"},
+					},
+				}},
+			},
+		},
+	}
+
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	var header metadata.MD
+	RegisterParamsWithoutHeader(queryClient, 1)
+	RegisterParams(queryClient, &header, 1)
+	_, err = RegisterBlockMultipleTxs(client, 1, []types.Tx{bankTxBz, ethTxBz})
+	suite.Require().NoError(err)
+	client.On("BlockResults", rpctypes.ContextWithHeight(1), mock.AnythingOfType("*int64")).Return(blockResults, nil)
+
+	suite.backend.indexer = indexer.NewKVIndexer(dbm.NewMemDB(), tmlog.NewNopLogger(), suite.backend.clientCtx)
+	block := types.MakeBlock(1, []types.Tx{bankTxBz, ethTxBz}, nil, nil)
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(block, blockResults.TxsResults))
+
+	receiptByHash, err := suite.backend.GetTransactionReceipt(ethMsg.Hash(), nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(hexutil.Uint64(21000), receiptByHash["cumulativeGasUsed"])
+
+	blockNum := rpctypes.BlockNumber(1)
+	blockReceipts, err := suite.backend.GetBlockReceipts(rpctypes.BlockNumberOrHash{BlockNumber: &blockNum})
+	suite.Require().NoError(err)
+	suite.Require().Len(blockReceipts, 1)
+	suite.Require().Equal(blockReceipts[0]["cumulativeGasUsed"], receiptByHash["cumulativeGasUsed"])
 }
 
 // TestGetTransactionReceipt_BlockScopedWhenIndexerOverwritten verifies that when


### PR DESCRIPTION
## What

Fix inconsistent `cumulativeGasUsed` values for Ethereum receipts in blocks containing both Cosmos and EVM transactions.

## Issue

`eth_getTransactionReceipt` included gas from preceding Cosmos transactions when calculating `cumulativeGasUsed`.

Block-scoped receipt APIs only accumulated gas from EVM transactions. As a result, the same Ethereum transaction could return different `cumulativeGasUsed` values depending on the RPC method used.

## Solution

- Reuse the block receipt reconstruction logic for hash-based receipt queries.
- Exclude preceding Cosmos transaction gas from `cumulativeGasUsed`.
- Preserve gas used by preceding EVM transactions.
- Add a regression test verifying that hash-based and block-scoped receipts return the same value.

## Testing

```bash
go test ./rpc/... -count=1 -timeout 20m
```
