### PR TITLE
fix(eip712): reject nonzero timeout_height on EIP-712 signing paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (eip712) [#1074](https://github.com/crypto-org-chain/ethermint/pull/1074) fix(eip712): reject nonzero timeout_height on EIP-712 signing paths.
 * (rpc) [#1063](https://github.com/crypto-org-chain/ethermint/pull/1063) fix(rpc): exclude preceding Cosmos transaction gas from Ethereum receipt `cumulativeGasUsed`.
 * (evm) [#1056](https://github.com/crypto-org-chain/ethermint/pull/1056) enforce EIP-7825 per-transaction gas limit cap (`MaxTxGas`) once Osaka activates.
 * (deps) [#1043](https://github.com/crypto-org-chain/ethermint/pull/1043) ffix(deps): bump Go to 1.25.11 to resolve stdlib vulnerabilities

--- a/ante/cosmos/eip712.go
+++ b/ante/cosmos/eip712.go
@@ -194,6 +194,11 @@ func VerifySignature(
 			return errorsmod.Wrap(errortypes.ErrNoSignatures, "tx doesn't contain any msgs to verify signature")
 		}
 
+		// timeout_height is not part of the legacy EIP-712 typed data schema, so it must be 0.
+		if tx.GetTimeoutHeight() != 0 {
+			return errorsmod.Wrap(errortypes.ErrInvalidRequest, "legacy EIP-712 signing does not commit timeout_height, so it must be 0")
+		}
+
 		txBytes := legacytx.StdSignBytes( //nolint:staticcheck
 			signerData.ChainID,
 			signerData.AccountNumber,

--- a/ante/cosmos/eip712.go
+++ b/ante/cosmos/eip712.go
@@ -194,7 +194,6 @@ func VerifySignature(
 			return errorsmod.Wrap(errortypes.ErrNoSignatures, "tx doesn't contain any msgs to verify signature")
 		}
 
-		// timeout_height is not part of the legacy EIP-712 typed data schema, so it must be 0.
 		if tx.GetTimeoutHeight() != 0 {
 			return errorsmod.Wrap(errortypes.ErrInvalidRequest, "legacy EIP-712 signing does not commit timeout_height, so it must be 0")
 		}

--- a/ante/cosmos/eip712_test.go
+++ b/ante/cosmos/eip712_test.go
@@ -90,6 +90,115 @@ func TestLegacyEIP712MixedMsg(t *testing.T) {
 		"expected error about different message types")
 }
 
+// TestLegacyEIP712TimeoutHeight tests that a legacy EIP-712 transaction with a
+// zero body timeout height succeeds, and that mutating the body's timeout
+// height to nonzero after signing is rejected, since timeout_height is not
+// part of the legacy typed data schema.
+func TestLegacyEIP712TimeoutHeight(t *testing.T) {
+	testCases := []struct {
+		name             string
+		bodyTimeoutAfter uint64 // nonzero: mutate builder timeout height after signing
+		expPass          bool
+	}{
+		{
+			name:    "zero timeout height succeeds",
+			expPass: true,
+		},
+		{
+			name:             "body timeout height mutated to nonzero after signing is rejected",
+			bodyTimeoutAfter: 1_000_000,
+			expPass:          false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := testutil.Setup(false, nil)
+			ctx := app.BaseApp.NewUncachedContext(false, tmproto.Header{ChainID: testutil.ChainID})
+			app.FeeMarketKeeper.SetBaseFee(ctx, big.NewInt(1))
+
+			privKey, err := ethsecp256k1.GenerateKey()
+			require.NoError(t, err)
+			delegator := sdk.AccAddress(privKey.PubKey().Address().Bytes())
+
+			acc := app.AccountKeeper.NewAccountWithAddress(ctx, delegator)
+			app.AccountKeeper.SetAccount(ctx, acc)
+
+			bondDenom, err := app.StakingKeeper.BondDenom(ctx)
+			require.NoError(t, err)
+			evmDenom := app.EvmKeeper.GetParams(ctx).EvmDenom
+			gas := uint64(500000)
+			delegationAmount := sdk.NewCoin(bondDenom, sdkmath.NewInt(100))
+			feeAmount := sdk.NewCoins(sdk.NewCoin(evmDenom, sdkmath.NewInt(100*int64(gas))))
+
+			require.NoError(t, testutil.FundAccount(
+				app.BankKeeper,
+				ctx,
+				delegator,
+				sdk.NewCoins(
+					sdk.NewCoin(bondDenom, delegationAmount.Amount.MulRaw(10)),
+					sdk.NewCoin(evmDenom, feeAmount.AmountOf(evmDenom).MulRaw(2)),
+				),
+			))
+
+			var valAddr sdk.ValAddress
+			err = app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) bool {
+				bz, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(val.GetOperator())
+				require.NoError(t, err)
+				valAddr = sdk.ValAddress(bz)
+				return true
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, valAddr)
+
+			msgs := []sdk.Msg{
+				stakingtypes.NewMsgDelegate(delegator.String(), valAddr.String(), delegationAmount),
+			}
+
+			txArgs := utiltx.EIP712TxArgs{
+				CosmosTxArgs: utiltx.CosmosTxArgs{
+					TxCfg:   app.TxConfig(),
+					Priv:    privKey,
+					ChainID: testutil.ChainID,
+					Gas:     gas,
+					Fees:    feeAmount,
+					Msgs:    msgs,
+					// TimeoutHeight left at 0: the sign doc always commits timeout 0.
+				},
+				UseLegacyExtension: true,
+				UseLegacyTypedData: true,
+			}
+
+			builder, err := utiltx.PrepareEIP712CosmosTx(ctx, app, txArgs)
+			require.NoError(t, err)
+
+			if tc.bodyTimeoutAfter != 0 {
+				// Mutate the tx body after signing: signature stays over timeout=0,
+				// but the body now carries a nonzero timeout height.
+				builder.SetTimeoutHeight(tc.bodyTimeoutAfter)
+			}
+
+			txBytes, err := app.TxConfig().TxEncoder()(builder.GetTx())
+			require.NoError(t, err)
+			height := app.LastBlockHeight() + 1
+			res, err := app.FinalizeBlock(&abci.RequestFinalizeBlock{
+				Height: height,
+				Txs:    [][]byte{txBytes},
+			})
+			require.NoError(t, err)
+			require.Len(t, res.TxResults, 1)
+
+			if tc.expPass {
+				require.Zero(t, res.TxResults[0].Code, "expected tx to succeed with zero timeout height, log: %s", res.TxResults[0].Log)
+				return
+			}
+
+			require.NotZero(t, res.TxResults[0].Code, "expected tx to fail with nonzero timeout height")
+			require.Contains(t, res.TxResults[0].Log, "legacy EIP-712 signing does not commit timeout_height, so it must be 0")
+		})
+	}
+}
+
 // TestLegacyEIP712SameMsgType tests that a legacy EIP-712 transaction with
 // multiple messages of the same type succeeds on-chain.
 func TestLegacyEIP712SameMsgType(t *testing.T) {

--- a/ante/cosmos/eip712_test.go
+++ b/ante/cosmos/eip712_test.go
@@ -90,10 +90,6 @@ func TestLegacyEIP712MixedMsg(t *testing.T) {
 		"expected error about different message types")
 }
 
-// TestLegacyEIP712TimeoutHeight tests that a legacy EIP-712 transaction with a
-// zero body timeout height succeeds, and that mutating the body's timeout
-// height to nonzero after signing is rejected, since timeout_height is not
-// part of the legacy typed data schema.
 func TestLegacyEIP712TimeoutHeight(t *testing.T) {
 	testCases := []struct {
 		name             string

--- a/ethereum/eip712/eip712_legacy.go
+++ b/ethereum/eip712/eip712_legacy.go
@@ -133,7 +133,7 @@ func extractMsgTypes(cdc codectypes.AnyUnpacker, msgTypeName string, msg sdk.Msg
 			{Name: "memo", Type: "string"},
 			{Name: "msgs", Type: "Msg[]"},
 			{Name: "sequence", Type: "string"},
-			// Note timeout_height was removed because it was not getting filled with the legacyTx
+			// timeout_height is intentionally omitted from this schema; the legacy path rejects any nonzero value instead.
 			// {Name: "timeout_height", Type: "string"},
 		},
 		"Fee": {

--- a/ethereum/eip712/eip712_test.go
+++ b/ethereum/eip712/eip712_test.go
@@ -472,10 +472,6 @@ func (suite *EIP712TestSuite) TestEIP712RejectsTimeoutTimestamp() {
 	suite.Require().False(pubKey.VerifySignature(timeoutBytes, sig), "signature must not verify against a body with a mutated timeout_timestamp")
 }
 
-// TestGetEIP712TypedDataForMsgRejectsAminoTimeoutHeight ensures that an amino
-// StdSignDoc carrying a nonzero timeout_height is rejected with an explicit
-// error on both the legacy and current paths, since neither typed data schema
-// includes timeout_height.
 func (suite *EIP712TestSuite) TestGetEIP712TypedDataForMsgRejectsAminoTimeoutHeight() {
 	suite.SetupTest()
 

--- a/ethereum/eip712/eip712_test.go
+++ b/ethereum/eip712/eip712_test.go
@@ -19,6 +19,7 @@ import (
 
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -469,6 +470,47 @@ func (suite *EIP712TestSuite) TestEIP712RejectsTimeoutTimestamp() {
 
 	suite.Require().True(pubKey.VerifySignature(cleanBytes, sig), "signature should verify against the signed tx")
 	suite.Require().False(pubKey.VerifySignature(timeoutBytes, sig), "signature must not verify against a body with a mutated timeout_timestamp")
+}
+
+// TestGetEIP712TypedDataForMsgRejectsAminoTimeoutHeight ensures that an amino
+// StdSignDoc carrying a nonzero timeout_height is rejected with an explicit
+// error on both the legacy and current paths, since neither typed data schema
+// includes timeout_height.
+func (suite *EIP712TestSuite) TestGetEIP712TypedDataForMsgRejectsAminoTimeoutHeight() {
+	suite.SetupTest()
+
+	// StdSignBytes requires RegressionTestingAminoCodec to be set; use the same
+	// amino codec eip712 decodes with, so message type names match.
+	legacytx.RegressionTestingAminoCodec = suite.config.Amino
+
+	_, pubKey := suite.createTestKeyPair()
+	signer := sdk.AccAddress(pubKey.Bytes())
+
+	msg := banktypes.NewMsgSend(
+		signer,
+		suite.createTestAddress(),
+		suite.makeCoins(suite.denom, math.NewInt(1)),
+	)
+
+	fee := legacytx.NewStdFee(20000, suite.makeCoins(suite.denom, math.NewInt(2000))) //nolint:staticcheck
+
+	signDocBytes := legacytx.StdSignBytes( //nolint:staticcheck
+		testutil.TestnetChainID+"-1",
+		25,
+		0,
+		1000, // nonzero timeout_height
+		fee,
+		[]sdk.Msg{msg},
+		"",
+	)
+
+	_, err := eip712.LegacyGetEIP712TypedDataForMsg(signDocBytes)
+	suite.Require().Error(err)
+	suite.Require().ErrorContains(err, "legacy EIP-712 signing does not commit timeout_height, so it must be 0")
+
+	_, err = eip712.GetEIP712TypedDataForMsg(signDocBytes)
+	suite.Require().Error(err)
+	suite.Require().ErrorContains(err, "EIP-712 signing does not commit timeout_height, so it must be 0")
 }
 
 // verifyEIP712SignatureVerification verifies that the payload passes signature verification if signed as its EIP-712 representation.

--- a/ethereum/eip712/encoding.go
+++ b/ethereum/eip712/encoding.go
@@ -115,6 +115,11 @@ func decodeAminoSignDoc(signDocBytes []byte) (apitypes.TypedData, error) {
 		return apitypes.TypedData{}, err
 	}
 
+	// timeout_height is not part of the EIP-712 typed data schema, so it must be 0.
+	if aminoDoc.TimeoutHeight != 0 {
+		return apitypes.TypedData{}, errors.New("EIP-712 signing does not commit timeout_height, so it must be 0")
+	}
+
 	chainID, err := types.ParseChainID(aminoDoc.ChainID)
 	if err != nil {
 		return apitypes.TypedData{}, errors.New("invalid chain ID passed as argument")

--- a/ethereum/eip712/encoding.go
+++ b/ethereum/eip712/encoding.go
@@ -115,7 +115,6 @@ func decodeAminoSignDoc(signDocBytes []byte) (apitypes.TypedData, error) {
 		return apitypes.TypedData{}, err
 	}
 
-	// timeout_height is not part of the EIP-712 typed data schema, so it must be 0.
 	if aminoDoc.TimeoutHeight != 0 {
 		return apitypes.TypedData{}, errors.New("EIP-712 signing does not commit timeout_height, so it must be 0")
 	}

--- a/ethereum/eip712/encoding_legacy.go
+++ b/ethereum/eip712/encoding_legacy.go
@@ -99,6 +99,11 @@ func legacyDecodeAminoSignDoc(signDocBytes []byte) (apitypes.TypedData, error) {
 		return apitypes.TypedData{}, err
 	}
 
+	// timeout_height is not part of the legacy EIP-712 typed data schema, so it must be 0.
+	if aminoDoc.TimeoutHeight != 0 {
+		return apitypes.TypedData{}, errors.New("legacy EIP-712 signing does not commit timeout_height, so it must be 0")
+	}
+
 	// Use first message for fee payer and type inference
 	msg := msgs[0]
 
@@ -154,13 +159,17 @@ func legacyDecodeProtobufSignDoc(signDocBytes []byte) (apitypes.TypedData, error
 		return apitypes.TypedData{}, err
 	}
 
+	// timeout_height is not part of the legacy EIP-712 typed data schema, so it must be 0.
+	if body.TimeoutHeight != 0 {
+		return apitypes.TypedData{}, errors.New("legacy EIP-712 signing does not commit timeout_height, so it must be 0")
+	}
+
 	// Until support for these fields is added, throw an error at their presence
-	if body.TimeoutHeight != 0 ||
-		body.GetTimeoutTimestamp() != nil ||
+	if body.GetTimeoutTimestamp() != nil ||
 		len(body.ExtensionOptions) != 0 ||
 		len(body.NonCriticalExtensionOptions) != 0 {
 		return apitypes.TypedData{}, errors.New(
-			"body contains unsupported fields: TimeoutHeight, TimeoutTimestamp, ExtensionOptions, or NonCriticalExtensionOptions",
+			"body contains unsupported fields: TimeoutTimestamp, ExtensionOptions, or NonCriticalExtensionOptions",
 		)
 	}
 

--- a/ethereum/eip712/encoding_legacy.go
+++ b/ethereum/eip712/encoding_legacy.go
@@ -99,7 +99,6 @@ func legacyDecodeAminoSignDoc(signDocBytes []byte) (apitypes.TypedData, error) {
 		return apitypes.TypedData{}, err
 	}
 
-	// timeout_height is not part of the legacy EIP-712 typed data schema, so it must be 0.
 	if aminoDoc.TimeoutHeight != 0 {
 		return apitypes.TypedData{}, errors.New("legacy EIP-712 signing does not commit timeout_height, so it must be 0")
 	}
@@ -159,7 +158,6 @@ func legacyDecodeProtobufSignDoc(signDocBytes []byte) (apitypes.TypedData, error
 		return apitypes.TypedData{}, err
 	}
 
-	// timeout_height is not part of the legacy EIP-712 typed data schema, so it must be 0.
 	if body.TimeoutHeight != 0 {
 		return apitypes.TypedData{}, errors.New("legacy EIP-712 signing does not commit timeout_height, so it must be 0")
 	}

--- a/ethereum/eip712/types.go
+++ b/ethereum/eip712/types.go
@@ -77,7 +77,7 @@ func createEIP712Types(messagePayload eip712MessagePayload) (apitypes.Types, err
 			{Name: "fee", Type: "Fee"},
 			{Name: "memo", Type: "string"},
 			{Name: "sequence", Type: "string"},
-			// Note timeout_height was removed because it was not getting filled with the legacyTx
+			// timeout_height is intentionally omitted from this schema; the sign doc decoders reject any nonzero value instead.
 		},
 		"Fee": {
 			{Name: "amount", Type: "Coin[]"},

--- a/testutil/tx/cosmos.go
+++ b/testutil/tx/cosmos.go
@@ -81,6 +81,7 @@ func PrepareCosmosTx(
 	}
 
 	txBuilder.SetFeeGranter(args.FeeGranter)
+	txBuilder.SetTimeoutHeight(args.TimeoutHeight)
 
 	return signCosmosTx(
 		ctx,

--- a/testutil/tx/cosmos.go
+++ b/testutil/tx/cosmos.go
@@ -52,6 +52,8 @@ type CosmosTxArgs struct {
 	FeeGranter sdk.AccAddress
 	// Msgs slice of messages to include on the tx
 	Msgs []sdk.Msg
+	// TimeoutHeight is the tx timeout height
+	TimeoutHeight uint64
 }
 
 // PrepareCosmosTx creates a cosmos tx and signs it with the provided messages and private key.

--- a/testutil/tx/eip712.go
+++ b/testutil/tx/eip712.go
@@ -17,7 +17,6 @@ package tx
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -97,12 +96,9 @@ func PrepareEIP712CosmosTx(
 	}
 	chainIDNum := pc.Uint64()
 
-	fmt.Println("args ", txArgs.Priv)
 	from := sdk.AccAddress(txArgs.Priv.PubKey().Address().Bytes())
-	fmt.Println("from ", from)
 	acc := appEthermint.AccountKeeper.GetAccount(ctx, from)
 
-	fmt.Println("acc: ", acc)
 	accNumber := acc.GetAccountNumber()
 
 	nonce, err := appEthermint.AccountKeeper.GetSequence(ctx, from)

--- a/testutil/tx/eip712.go
+++ b/testutil/tx/eip712.go
@@ -113,7 +113,7 @@ func PrepareEIP712CosmosTx(
 	fee := legacytx.NewStdFee(txArgs.Gas, txArgs.Fees) //nolint:staticcheck
 
 	msgs := txArgs.Msgs
-	data := legacytx.StdSignBytes(ctx.ChainID(), accNumber, nonce, 0, fee, msgs, "") //nolint:staticcheck
+	data := legacytx.StdSignBytes(ctx.ChainID(), accNumber, nonce, txArgs.TimeoutHeight, fee, msgs, "") //nolint:staticcheck
 
 	typedDataArgs := typedDataArgs{
 		chainID:        chainIDNum,
@@ -135,6 +135,7 @@ func PrepareEIP712CosmosTx(
 
 	builder.SetFeeAmount(fee.Amount)
 	builder.SetGasLimit(txArgs.Gas)
+	builder.SetTimeoutHeight(txArgs.TimeoutHeight)
 
 	err = builder.SetMsgs(txArgs.Msgs...)
 	if err != nil {


### PR DESCRIPTION
### What

Both the legacy and current EIP-712 typed data `Tx` schemas omit `timeout_height`, but the sign-doc bytes fed into the typed data hash (`legacytx.StdSignBytes`) still include it. So `timeout_height` was never actually bound by the signature on either path. This affects `ante/cosmos/eip712.go` (legacy Web3Tx verification) and both `ethereum/eip712/encoding.go` and `ethereum/eip712/encoding_legacy.go` (typed data construction for both schemas).

### Issue

A nonzero `timeout_height` currently gets rejected only by accident: geth's `apitypes.TypedData.EncodeData` errors on extra message keys once `timeout_height` is added to the JSON sign doc but not the typed data schema (`there is extra data provided in the message`). This means:

- Any legacy or current EIP-712 tx signed with a nonzero timeout height fails today, both to sign and to verify, with a confusing error unrelated to the real cause.
- The invariant "signature does not cover timeout_height" is not actually enforced by design, just by a side effect of the schema/sign-doc mismatch. That's fragile and easy to break by an unrelated change (e.g. altering the JSON encoding of the sign doc).

The fix does not add `timeout_height` to either schema, since that would change the typed-data hash of every currently working (`timeout_height = 0`) EIP-712 tx and break existing wallets. Instead, it makes the "must be zero" rule explicit and independent of geth's incidental behavior.

### Solution

- `ante/cosmos/eip712.go`: `VerifySignature` now rejects `tx.GetTimeoutHeight() != 0` before building sign bytes for legacy EIP-712 verification.
- `ethereum/eip712/encoding_legacy.go`: both `legacyDecodeAminoSignDoc` and `legacyDecodeProtobufSignDoc` explicitly reject nonzero `timeout_height` instead of letting it fall into geth's typed-data error.
- `ethereum/eip712/encoding.go`: `decodeAminoSignDoc` gets the same explicit check (the protobuf decoder, `decodeProtobufSignDoc`, already rejected `TimeoutHeight` explicitly).
- Comments at the schema definitions (`eip712_legacy.go`, `types.go`) updated to state the omission is intentional and enforced.
- `testutil/tx`: added a `TimeoutHeight` field to `CosmosTxArgs`, wired into both the EIP-712 sign doc and the tx builder, to support testing a tx whose body timeout height differs from what was signed.
